### PR TITLE
Bump rails version requirement for compact_blank

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     kredis (0.2.0)
-      rails (>= 6.0.0)
+      rails (>= 6.1.0)
       redis (~> 4.0)
 
 GEM

--- a/kredis.gemspec
+++ b/kredis.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license  = "MIT"
 
   s.required_ruby_version = ">= 2.7.0"
-  s.add_dependency "rails", ">= 6.0.0"
+  s.add_dependency "rails", ">= 6.1.0"
   s.add_dependency "redis", "~> 4.0"
 
   s.files = Dir["lib/**/*", "MIT-LICENSE", "README.md"]


### PR DESCRIPTION
ActiveSupport's `Enumerable#compact_blank` (used [here](https://github.com/rails/kredis/blob/a7e64f3d0efecae906f78a836bb6a10ea1183000/lib/kredis/types/proxy.rb#L22)) wasn't added until [this commit](https://github.com/rails/rails/commit/c8847c17a7c9ae75c44c522c56ccd9c5fca25ea7), which wasn't included until Rails 6.1 as per the [changelog](https://github.com/rails/rails/blob/v6.1.1/activesupport/CHANGELOG.md). I bumped the requirement to Rails 6.1 in the gemspec in order to account for this. I understand if you want to support Rails 6.0, in which case I can instead just change `compact_blank` to `reject(&:blank?)`