### PR TITLE
Add support for set difference

### DIFF
--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -1,5 +1,8 @@
 class Kredis::Types::Set < Kredis::Types::Proxying
-  proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop, :sdiff, :sdiffstore
+  proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop,
+           :sdiff, :sdiffstore,
+           :sunion, :sunionstore,
+           :sinter, :sinterstore
 
   attr_accessor :typed
 
@@ -49,6 +52,30 @@ class Kredis::Types::Set < Kredis::Types::Proxying
       store.sdiffstore key, value.key
     else
       sdiff value.key
+    end
+  end
+
+  def &(value)
+    intersection value
+  end
+
+  def intersection(value, store: nil)
+    if store
+      store.sinterstore key, value.key
+    else
+      sinter value.key
+    end
+  end
+
+  def +(value)
+    union value
+  end
+
+  def union(value, store: nil)
+    if store
+      store.sunionstore key, value.key
+    else
+      sunion value.key
     end
   end
 end

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -1,5 +1,5 @@
 class Kredis::Types::Set < Kredis::Types::Proxying
-  proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop
+  proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop, :sdiff, :sdiffstore
 
   attr_accessor :typed
 
@@ -38,5 +38,17 @@ class Kredis::Types::Set < Kredis::Types::Proxying
 
   def clear
     del
+  end
+
+  def -(value)
+    diff value
+  end
+
+  def diff(value, store: nil)
+    if store
+      store.sdiffstore key, value.key
+    else
+      sdiff value.key
+    end
   end
 end

--- a/test/types/set_test.rb
+++ b/test/types/set_test.rb
@@ -81,6 +81,42 @@ class SetTest < ActiveSupport::TestCase
     assert_equal result.members, %w[1 5]
   end
 
+  test "+" do
+    @set.add %w[1 2 3 4 5]
+    otherset = Kredis.set "otherset"
+    otherset.add %w[5 6 7 8 9]
+    assert_equal (@set + otherset), %w[1 2 3 4 5 6 7 8 9]
+  end
+
+  test "union" do
+    @set.add %w[1 2 3 4 5]
+    otherset = Kredis.set "otherset"
+    otherset.add %w[5 6 7 8 9]
+    assert_equal (@set.union(otherset)), %w[1 2 3 4 5 6 7 8 9]
+
+    result = Kredis.set "resultset"
+    @set.union(otherset, store: result)
+    assert_equal result.members, %w[1 2 3 4 5 6 7 8 9]
+  end
+
+  test "&" do
+    @set.add %w[1 2 3 4 5]
+    otherset = Kredis.set "otherset"
+    otherset.add %w[4 5 6 7]
+    assert_equal (@set & otherset), %w[4 5]
+  end
+
+  test "intersection" do
+    @set.add %w[1 2 3 4 5]
+    otherset = Kredis.set "otherset"
+    otherset.add %w[4 5 6 7]
+    assert_equal (@set.intersection(otherset)), %w[4 5]
+
+    result = Kredis.set "resultset"
+    @set.intersection(otherset, store: result)
+    assert_equal result.members, %w[4 5]
+  end
+
   test "typed as floats" do
     @set = Kredis.set "mylist", typed: :float
 

--- a/test/types/set_test.rb
+++ b/test/types/set_test.rb
@@ -63,6 +63,24 @@ class SetTest < ActiveSupport::TestCase
     assert_equal [], @set.members
   end
 
+  test "-" do
+    @set.add %w[1 2 3 4 5]
+    subset = Kredis.set "otherset"
+    subset.add %w[2 3 4]
+    assert_equal (@set - subset), %w[1 5]
+  end
+
+  test "diff" do
+    @set.add %w[1 2 3 4 5]
+    subset = Kredis.set "otherset"
+    subset.add %w[2 3 4]
+    assert_equal (@set.diff(subset)), %w[1 5]
+
+    result = Kredis.set "resultset"
+    @set.diff(subset, store: result)
+    assert_equal result.members, %w[1 5]
+  end
+
   test "typed as floats" do
     @set = Kredis.set "mylist", typed: :float
 


### PR DESCRIPTION
This adds support for Redis' [SDIFF](https://redis.io/commands/sdiff) and [SDIFFSTORE](https://redis.io/commands/sdiffstore) operations allowing us to efficiently calculate set difference and, optionally, store the result in another Kredis key.

It looks like this:

```ruby
jamie = Kredis.set 'set1', typed: :string
jam = Kredis.set 'set2', typed: :string

jamie << %w(j a m i e) 
jam << %w(j a m) 

# SDIFF
jamie - jam #=> ["i", "e"]
jamie.diff jam #=> ["i", "e"]

# SDIFFSTORE which avoids the need to return the result to ruby
result = Kredis.set 'resultset'
jamie.diff jam, store: result
result.members #=> ["i", "e"]
```

I'm not sure if this is a direction you'd like Kredis to go in but it would be easy enough to add `SUNION` (`set + otherset`) and `SINTER` (`set & otherset`) operations to mirror the same operations in Array. Happy to write PRs for those operations too or expand this one