### PR TITLE
Update README for reading the members of a Kredis.set

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ unique_list.remove(3)
 [ "1", "2", "4", "5" ] == unique_list.elements
 
 set = Kredis.set "myset", typed: :datetime
-set.add(DateTime.tomorrow, DateTime.yesterday)            # => SADD myset "2021-02-03 00:00:00 +0100" "2021-02-01 00:00:00 +0100"
-set << DateTime.tomorrow                                  # => SADD myset "2021-02-03 00:00:00 +0100"
-2 == set.size                                             # => SCARD myset
-[ DateTime.tomorrow, DateTime.yesterday ] == set.elements # => SMEMBERS myset
+set.add(DateTime.tomorrow, DateTime.yesterday)           # => SADD myset "2021-02-03 00:00:00 +0100" "2021-02-01 00:00:00 +0100"
+set << DateTime.tomorrow                                 # => SADD myset "2021-02-03 00:00:00 +0100"
+2 == set.size                                            # => SCARD myset
+[ DateTime.tomorrow, DateTime.yesterday ] == set.members # => SMEMBERS myset
 
 head_count = Kredis.counter "headcount"
 0 == head_count.value              # => GET "headcount"


### PR DESCRIPTION
The README example for `Kredis.set` was sending the message `elements` to read the members of a set.  Following that example resulted in a runtime error.

Looking into the implementation of [Kredis::Types::Set][], it appears that `members` is the correct method for reading the members?

[Kredis::Types::Set]: https://github.com/rails/kredis/blob/ab79f255c53bfb5e760c08644222af6fe215f253/lib/kredis/types/set.rb#L6-L8