### PR TITLE
Add kredis_boolean attribute with default argument

### DIFF
--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -14,6 +14,10 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, config: config
     end
 
+    def kredis_boolean(name, key: nil, default: nil, config: :shared)
+      kredis_connection_with __method__, name, key, default: default, config: config
+    end
+
     def kredis_datetime(name, key: nil, config: :shared)
       kredis_connection_with __method__, name, key, config: config
     end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -19,6 +19,7 @@ class Person
   kredis_set :vacations
   kredis_json :settings
   kredis_counter :amount
+  kredis_boolean :noodling, default: false
 
   def self.name
     "Person"
@@ -96,6 +97,12 @@ class AttributesTest < ActiveSupport::TestCase
     @person.age.value = 41
     assert_equal 41, @person.age.value
     assert_equal "41", @person.age.to_s
+  end
+
+  test "boolean" do
+    assert_equal false, @person.noodling.value
+    @person.noodling.value = true
+    assert_equal true, @person.noodling.value
   end
 
   test "datetime" do


### PR DESCRIPTION
Add `kredis_boolean`. Follows in the same vein of existing attributes (e.g. `kredis_integer`). The only difference being I added `default` as an argument:

```
kredis_boolean :noodling, default: false
```