### PR TITLE
Depend only on activesupport.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     kredis (0.2.3)
-      rails (>= 6.0.0)
+      activesupport (>= 6.0.0)
       redis (~> 4.2)
 
 GEM
@@ -148,6 +148,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   kredis!
+  rails (>= 6.0.0)
   rake
 
 BUNDLED WITH

--- a/kredis.gemspec
+++ b/kredis.gemspec
@@ -10,8 +10,9 @@ Gem::Specification.new do |s|
   s.license  = "MIT"
 
   s.required_ruby_version = ">= 2.7.0"
-  s.add_dependency "rails", ">= 6.0.0"
+  s.add_dependency "activesupport", ">= 6.0.0"
   s.add_dependency "redis", "~> 4.2"
+  s.add_development_dependency "rails", ">= 6.0.0"
 
   s.files = Dir["lib/**/*", "MIT-LICENSE", "README.md"]
 end


### PR DESCRIPTION
Hi,

I have some non-rails projects that this would be great for. I was wondering if depending on just activesupport would make sense to reduce the number of dependencies that get installed along with it in a non-rails context?

Thanks for kredis!