### PR TITLE
Allow false value to be returned for Boolean scalar

### DIFF
--- a/lib/kredis/types/scalar.rb
+++ b/lib/kredis/types/scalar.rb
@@ -8,7 +8,10 @@ class Kredis::Types::Scalar < Kredis::Types::Proxying
   end
 
   def value
-    string_to_type(get, typed) || default
+    value_after_casting = string_to_type(get, typed)
+    return default if value_after_casting.nil?
+
+    value_after_casting
   end
 
   def to_s

--- a/lib/kredis/types/scalar.rb
+++ b/lib/kredis/types/scalar.rb
@@ -9,9 +9,12 @@ class Kredis::Types::Scalar < Kredis::Types::Proxying
 
   def value
     value_after_casting = string_to_type(get, typed)
-    return default if value_after_casting.nil?
-
-    value_after_casting
+    
+    if value_after_casting.nil?
+      default
+    else
+      value_after_casting
+    end
   end
 
   def to_s

--- a/test/types/scalar_test.rb
+++ b/test/types/scalar_test.rb
@@ -30,6 +30,12 @@ class ScalarTest < ActiveSupport::TestCase
     boolean = Kredis.boolean "myscalar"
     boolean.value = true
     assert_equal true, boolean.value
+    boolean.value = false
+    assert_equal false, boolean.value
+    boolean.value = 't'
+    assert_equal true, boolean.value
+    boolean.value = 'false'
+    assert_equal false, boolean.value
   end
 
   test "datetime" do


### PR DESCRIPTION
**Expected behaviour**
If we set the value of a `Kredis.boolean` to `false`, then I would expect `false` to be returned for that value. For example:

```rb
boolean = Kredis.boolean "myscalar"
boolean.value = false
assert_equal false, boolean.value
```

**Actual behaviour**

If we set a  `Kredis.boolean` value to `false`, then `nil` will be returned for that value.

```rb
boolean = Kredis.boolean "myscalar"
boolean.value = false
boolean.value # nil
```

**Reasoning**

`default` is always returned rather than the cast value when converting a string to a boolean. 

As `string_to_type` can return a `false` value, the double pipe (`||`) will always return `default`, even though `false` may be the desired return value.

https://github.com/rails/kredis/blob/76efacfc705c8825d8f7d2e6cfe6f30d6e451eed/lib/kredis/types/scalar.rb#L11



This PR aims to allow `false` to be returned for Booleans.