### PR TITLE
Order the Ruby `require` statements and the Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
 gem "byebug"
+gem "rake"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Kredis is configured using env-aware YAML files, using `Rails.application.config
 
 Kredis provides namespacing support for keys such that you can safely run parallel testing against the data structures without different tests trampling each others data.
 
-
 ## Examples
 
 Kredis provides typed scalars for strings, integers, decimals, floats, booleans, datetimes, and JSON hashes:
@@ -139,7 +138,6 @@ person.morning.value = "blue"                        # => SET people:1:morning
 true == person.morning.blue?                         # => GET people:1:morning
 ```
 
-
 ## Installation
 
 1. Add the `kredis` gem to your Gemfile: `gem 'kredis'`
@@ -164,7 +162,6 @@ test:
 ```
 
 Additional configurations can be added under `config/redis/*.yml` and referenced when a type is created, e.g. `Kredis.string("mystring", config: :strings)` would lookup `config/redis/strings.yml`. Under the hood `Kredis.configured_for` is called which'll pass the configuration on to `Redis.new`.
-
 
 ## License
 

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -3,7 +3,6 @@ module Kredis::Types
     Proxy.new configured_for(config), namespaced_key(key)
   end
 
-
   def scalar(key, typed: :string, default: nil, config: :shared)
     Scalar.new configured_for(config), namespaced_key(key), typed: typed, default: default
   end
@@ -35,7 +34,6 @@ module Kredis::Types
   def json(key, default: nil, config: :shared)
     Scalar.new configured_for(config), namespaced_key(key), typed: :json, default: default
   end
-
 
   def counter(key, expires_in: nil, config: :shared)
     Counter.new configured_for(config), namespaced_key(key), expires_in: expires_in
@@ -74,15 +72,14 @@ module Kredis::Types
   end
 end
 
-require "kredis/types/proxy"
-require "kredis/types/proxying"
-
-require "kredis/types/scalar"
 require "kredis/types/counter"
 require "kredis/types/cycle"
-require "kredis/types/flag"
 require "kredis/types/enum"
+require "kredis/types/flag"
 require "kredis/types/list"
-require "kredis/types/unique_list"
+require "kredis/types/proxy"
+require "kredis/types/proxying"
+require "kredis/types/scalar"
 require "kredis/types/set"
 require "kredis/types/slots"
+require "kredis/types/unique_list"


### PR DESCRIPTION
Remove unneeded blank lines from Markdown and Ruby.