### PR TITLE
Utilize ActiveSupport instrumentation for logging

### DIFF
--- a/lib/kredis.rb
+++ b/lib/kredis.rb
@@ -4,6 +4,7 @@ require "active_support/core_ext/module/attribute_accessors"
 require "kredis/version"
 
 require "kredis/connections"
+require "kredis/log_subscriber"
 require "kredis/namespace"
 require "kredis/type_casting"
 require "kredis/types"
@@ -22,5 +23,9 @@ module Kredis
 
   def redis(config: :shared)
     configured_for(config)
+  end
+
+  def instrument(channel, **options)
+    ActiveSupport::Notifications.instrument("#{channel}.kredis", **options)
   end
 end

--- a/lib/kredis/connections.rb
+++ b/lib/kredis/connections.rb
@@ -6,13 +6,13 @@ module Kredis::Connections
 
   def configured_for(name)
     connections[name] ||= begin
-      logger&.info "[Kredis] Connected to #{name}"
+      Kredis.instrument :meta, message: "Connected to #{name}"
       Redis.new configurator.config_for("redis/#{name}")
     end
   end
 
   def clear_all
-    logger&.info "[Kredis] Connections all cleared"
+    Kredis.instrument :meta, message: "Connections all cleared"
     connections.each_value do |connection|
       if Kredis.namespace
         keys = connection.keys("#{Kredis.namespace}:*")

--- a/lib/kredis/log_subscriber.rb
+++ b/lib/kredis/log_subscriber.rb
@@ -1,0 +1,25 @@
+require "active_support/log_subscriber"
+
+class Kredis::LogSubscriber < ActiveSupport::LogSubscriber
+  def proxy(event)
+    duration = "#{event.duration.round(1)}ms"
+    name = color("Kredis #{event.payload[:type]} (#{duration})", YELLOW, true)
+
+    debug "  #{name}  #{color(event.payload[:message], YELLOW, true)}"
+  end
+
+  def migration(event)
+    duration = "#{event.duration.round(1)}ms"
+    name = color("Kredis Migration (#{duration})", YELLOW, true)
+
+    debug "  #{name}  #{color(event.payload[:message], YELLOW, true)}"
+  end
+
+  def meta(event)
+    name = color("Kredis (#{event.duration.round(1)}ms)", MAGENTA, true)
+
+    info "  #{name}  #{color(event.payload[:message], MAGENTA, true)}"
+  end
+end
+
+Kredis::LogSubscriber.attach_to :kredis

--- a/lib/kredis/migration.rb
+++ b/lib/kredis/migration.rb
@@ -47,6 +47,6 @@ class Kredis::Migration
     end
 
     def log_migration(message)
-      Kredis.logger&.debug "[Kredis Migration] #{message}"
+      Kredis.instrument :migration, message: message
     end
 end

--- a/lib/kredis/railtie.rb
+++ b/lib/kredis/railtie.rb
@@ -9,7 +9,7 @@ class Kredis::Railtie < ::Rails::Railtie
   end
 
   initializer "kredis.logger" do
-    Kredis.logger = config.kredis.logger || Rails.logger
+    Kredis::LogSubscriber.logger = config.kredis.logger || Rails.logger
   end
 
   initializer "kredis.configurator" do

--- a/lib/kredis/types/proxy.rb
+++ b/lib/kredis/types/proxy.rb
@@ -15,7 +15,7 @@ class Kredis::Types::Proxy
 
   def method_missing(method, *args, **kwargs)
     failsafe do
-      Kredis.logger&.debug log_message(method, *args, **kwargs)
+      Kredis.instrument :proxy, **log_message(method, *args, **kwargs)
       redis.public_send method, key, *args, **kwargs
     end
   end
@@ -26,6 +26,7 @@ class Kredis::Types::Proxy
       kwargs    = kwargs.reject { |_k, v| v.blank? }.presence
       type_name = self.class.name.split("::").last
 
-      "[Kredis #{type_name}] #{method.upcase} #{key} #{args&.inspect} #{kwargs&.inspect}".chomp
+      { type: type_name,
+        message: "#{method.upcase} #{key} #{args&.inspect} #{kwargs&.inspect}".chomp }
     end
 end

--- a/test/log_subscriber_test.rb
+++ b/test/log_subscriber_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+require "active_support/log_subscriber/test_helper"
+
+class LogSubscriberTest < ActiveSupport::TestCase
+  include ActiveSupport::LogSubscriber::TestHelper
+
+  setup do
+    @log_subscriber = Kredis::LogSubscriber.new
+  end
+
+  teardown do
+    ActiveSupport::LogSubscriber.log_subscribers.clear
+  end
+
+  test "#proxy" do
+    ActiveSupport::LogSubscriber.colorize_logging = true
+    ActiveSupport::LogSubscriber.attach_to :kredis, @log_subscriber
+    instrument "proxy.kredis", message: "foo", type: "bar"
+    wait
+
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(
+      /\e\[1m\e\[33mKredis bar \(\d+\.\d+ms\)\e\[0m  \e\[1m\e\[33mfoo\e\[0m/,
+      @logger.logged(:debug).last
+    )
+  end
+
+  test "#migration" do
+    ActiveSupport::LogSubscriber.colorize_logging = true
+    ActiveSupport::LogSubscriber.attach_to :kredis, @log_subscriber
+    instrument "migration.kredis", message: "foo"
+    wait
+
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(
+      /\e\[1m\e\[33mKredis Migration \(\d+\.\d+ms\)\e\[0m  \e\[1m\e\[33mfoo\e\[0m/,
+      @logger.logged(:debug).last
+    )
+  end
+
+  test "#meta" do
+    ActiveSupport::LogSubscriber.colorize_logging = true
+    ActiveSupport::LogSubscriber.attach_to :kredis, @log_subscriber
+    instrument "meta.kredis", message: "foo"
+    wait
+
+    assert_equal 1, @logger.logged(:info).size
+    assert_match(
+      /\e\[1m\e\[35mKredis \(\d+\.\d+ms\)\e\[0m  \e\[1m\e\[35mfoo\e\[0m/,
+      @logger.logged(:info).last
+    )
+  end
+
+  private
+
+  def instrument(*args, &block)
+    ActiveSupport::Notifications.instrument(*args, &block)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,8 @@ require "kredis"
 
 Kredis.configurator = Class.new { def config_for(name) {} end }.new
 
-Kredis.logger = Logger.new(STDOUT) if ENV["VERBOSE"]
+ActiveSupport::LogSubscriber.logger =
+  ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 
 class ActiveSupport::TestCase
   teardown { Kredis.clear_all }


### PR DESCRIPTION
Using ActiveSupport instrumentation allows us to track the duration and
have more control over logging.