### PR TITLE
Proposal: Yield elements to block for collection mutations

### DIFF
--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -10,14 +10,22 @@ class Kredis::Types::List < Kredis::Types::Proxying
 
   def remove(*elements)
     types_to_strings(elements).each { |element| lrem 0, element }
+
+    yield send(:elements) if block_given?
   end
 
   def prepend(*elements)
     lpush types_to_strings(elements) if elements.flatten.any?
+
+    # if called from a subclass/in a multi, don't yield from here
+    yield send(:elements) if block_given? && !(self.class < Kredis::Types::List)
   end
 
   def append(*elements)
     rpush types_to_strings(elements) if elements.flatten.any?
+
+    # if called from a subclass/in a multi, don't yield from here
+    yield send(:elements) if block_given? && !(self.class < Kredis::Types::List)
   end
   alias << append
 end

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -10,11 +10,15 @@ class Kredis::Types::Set < Kredis::Types::Proxying
 
   def add(*members)
     sadd types_to_strings(members) if members.flatten.any?
+
+    yield send(:members) if block_given?
   end
   alias << add
 
   def remove(*members)
     srem types_to_strings(members) if members.flatten.any?
+
+    yield send(:members) if block_given?
   end
 
   def replace(*members)
@@ -22,6 +26,8 @@ class Kredis::Types::Set < Kredis::Types::Proxying
       del
       add members
     end
+
+    yield send(:members) if block_given?
   end
 
   def include?(member)

--- a/lib/kredis/types/unique_list.rb
+++ b/lib/kredis/types/unique_list.rb
@@ -10,6 +10,8 @@ class Kredis::Types::UniqueList < Kredis::Types::List
       super
       ltrim 0, (limit - 1) if limit
     end if Array(elements).flatten.any?
+
+    yield send(:elements) if block_given?
   end
 
   def append(elements)
@@ -18,6 +20,8 @@ class Kredis::Types::UniqueList < Kredis::Types::List
       super
       ltrim (limit - 1), -1 if limit
     end if Array(elements).flatten.any?
+
+    yield send(:elements) if block_given?
   end
   alias << append
 end

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -10,6 +10,14 @@ class ListTest < ActiveSupport::TestCase
     assert_equal %w[ 1 2 3 4 ], @list.elements
   end
 
+  test "append yields elements to block" do
+    yielded_elements = []
+    @list.append(%w[ 1 2 3 ]) do |elements|
+      yielded_elements = elements
+    end
+    assert_equal %w[ 1 2 3 ], yielded_elements
+  end
+
   test "append nothing" do
     @list.append(%w[ 1 2 3 ])
     @list.append([])
@@ -20,6 +28,14 @@ class ListTest < ActiveSupport::TestCase
     @list.prepend(%w[ 1 2 3 ])
     @list.prepend(4)
     assert_equal %w[ 4 3 2 1 ], @list.elements
+  end
+
+  test "prepend yields elements to block" do
+    yielded_elements = []
+    @list.prepend(%w[ 1 2 3 ]) do |elements|
+      yielded_elements = elements
+    end
+    assert_equal %w[ 3 2 1 ], yielded_elements
   end
 
   test "prepend nothing" do
@@ -33,6 +49,15 @@ class ListTest < ActiveSupport::TestCase
     @list.remove(%w[ 1 2 ])
     @list.remove(3)
     assert_equal %w[ 4 ], @list.elements
+  end
+
+  test "remove yields elements to the block" do
+    yielded_elements = []
+    @list.append(%w[ 1 2 3 4 ])
+    @list.remove(%w[ 1 2 ]) do |elements|
+      yielded_elements = elements
+    end
+    assert_equal %w[ 3 4 ], yielded_elements
   end
 
   test "typed as datetime" do

--- a/test/types/set_test.rb
+++ b/test/types/set_test.rb
@@ -17,6 +17,15 @@ class SetTest < ActiveSupport::TestCase
     assert_equal %w[ 1 2 3 ], @set.to_a
   end
 
+  test "add yields members to block" do
+    yielded_members = []
+    @set.add(%w[ 1 2 3 ]) do |members|
+      yielded_members = members
+    end
+
+    assert_equal %w[ 1 2 3 ], yielded_members
+  end
+
   test "remove" do
     @set.add(%w[ 1 2 3 4 ])
     @set.remove(%w[ 2 3 ])
@@ -30,10 +39,28 @@ class SetTest < ActiveSupport::TestCase
     assert_equal %w[ 1 2 3 4 ], @set.members
   end
 
+  test "remove yields members to the block" do
+    yielded_members = []
+    @set.add(%w[ 1 2 3 4 ])
+    @set.remove(%w[ 2 3 ]) do |members|
+      yielded_members = members
+    end
+    assert_equal %w[ 1 4 ], yielded_members
+  end
+
   test "replace" do
     @set.add(%w[ 1 2 3 4 ])
     @set.replace(%w[ 5 6 ])
     assert_equal %w[ 5 6 ], @set.members
+  end
+
+  test "replace yields members to the block" do
+    yielded_members = []
+    @set.add(%w[ 1 2 3 4 ])
+    @set.replace(%w[ 5 6 ]) do |members|
+      yielded_members = members
+    end
+    assert_equal %w[ 5 6 ], yielded_members
   end
 
   test "include" do

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -30,6 +30,24 @@ class UniqueListTest < ActiveSupport::TestCase
     assert_equal %w[ 3 2 1 ], @list.elements
   end
 
+  test "append yields elements to block" do
+    yielded_elements = []
+    @list.append(%w[ 1 2 3 ])
+    @list.append(%w[ 1 2 3 4 ]) do |elements|
+      yielded_elements = elements
+    end
+    assert_equal %w[ 1 2 3 4 ], yielded_elements
+  end
+
+  test "prepend yields elements to block" do
+    yielded_elements = []
+    @list.prepend(%w[ 1 2 3 ])
+    @list.prepend(%w[ 1 2 3 4 ]) do |elements|
+      yielded_elements = elements
+    end
+    assert_equal %w[ 4 3 2 1 ], yielded_elements
+  end
+
   test "typed as integers" do
     @list = Kredis.unique_list "mylist", typed: :integer
 


### PR DESCRIPTION
This PR adds the changes mentioned in https://github.com/rails/kredis/issues/17#issuecomment-852177492

Doing that I was able to write a simple presence module that streams a CableReady operation to display a list of users currently viewing a resource:

```rb
resource.present_users.add(current_user.id) do |members|
  StreamPresenceJob.perform_later(members)
end
```

From here it's not a wide stretch to assume that a `Proc` could be placed on the model itself, or a wrapper function defined inside a concern for adding/removing ids to/from the set that allows for this operation.

I think this is a great, lightweight way to report the result of a mutation back to the caller. For the record, simply calling `.members` after an `.add` operation didn't cut it, assumingly because of threaded operation.
