### PR TITLE
Changed Callbacks

### DIFF
--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -38,16 +38,16 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, config: config
     end
 
-    def kredis_list(name, key: nil, typed: :string, config: :shared)
-      kredis_connection_with __method__, name, key, typed: typed, config: config
+    def kredis_list(name, key: nil, typed: :string, config: :shared, changed: ->(list){})
+      kredis_connection_with __method__, name, key, typed: typed, config: config, changed: changed
     end
 
-    def kredis_unique_list(name, limit: nil, key: nil, typed: :string, config: :shared)
-      kredis_connection_with __method__, name, key, limit: limit, typed: typed, config: config
+    def kredis_unique_list(name, limit: nil, key: nil, typed: :string, config: :shared, changed: ->(list){})
+      kredis_connection_with __method__, name, key, limit: limit, typed: typed, config: config, changed: changed
     end
 
-    def kredis_set(name, key: nil, typed: :string, config: :shared)
-      kredis_connection_with __method__, name, key, typed: typed, config: config
+    def kredis_set(name, key: nil, typed: :string, config: :shared, changed: ->(set){})
+      kredis_connection_with __method__, name, key, typed: typed, config: config, changed: changed
     end
 
     def kredis_slot(name, key: nil, config: :shared)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -53,8 +53,8 @@ module Kredis::Types
     Enum.new configured_for(config), namespaced_key(key), values: values, default: default
   end
 
-  def list(key, typed: :string, config: :shared)
-    List.new configured_for(config), namespaced_key(key), typed: typed
+  def list(key, typed: :string, config: :shared, changed: ->(list){})
+    List.new configured_for(config), namespaced_key(key), typed: typed, changed: changed
   end
 
   def unique_list(key, typed: :string, limit: nil, config: :shared)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -57,8 +57,8 @@ module Kredis::Types
     List.new configured_for(config), namespaced_key(key), typed: typed, changed: changed
   end
 
-  def unique_list(key, typed: :string, limit: nil, config: :shared)
-    UniqueList.new configured_for(config), namespaced_key(key), typed: typed, limit: limit
+  def unique_list(key, typed: :string, limit: nil, config: :shared, changed: ->(unique_list){})
+    UniqueList.new configured_for(config), namespaced_key(key), typed: typed, limit: limit, changed: changed
   end
 
   def set(key, typed: :string, config: :shared, changed: ->(set){})

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -61,8 +61,8 @@ module Kredis::Types
     UniqueList.new configured_for(config), namespaced_key(key), typed: typed, limit: limit
   end
 
-  def set(key, typed: :string, config: :shared)
-    Set.new configured_for(config), namespaced_key(key), typed: typed
+  def set(key, typed: :string, config: :shared, changed: ->(set){})
+    Set.new configured_for(config), namespaced_key(key), typed: typed, changed: changed
   end
 
   def slot(key, config: :shared)
@@ -76,6 +76,7 @@ end
 
 require "kredis/types/proxy"
 require "kredis/types/proxying"
+require "kredis/types/callbacks"
 
 require "kredis/types/scalar"
 require "kredis/types/counter"

--- a/lib/kredis/types/callbacks.rb
+++ b/lib/kredis/types/callbacks.rb
@@ -1,5 +1,14 @@
 module Kredis::Types::Callbacks
   extend ActiveSupport::Concern
+  include ActiveSupport::Callbacks
+
+  included do
+    define_callbacks :change
+
+    set_callback :change, :after do |object|
+      @changed_callback&.call(object)
+    end
+  end
 
   def initialize(redis, key, changed: ->(set){}, **options)
     super redis, key, **options

--- a/lib/kredis/types/callbacks.rb
+++ b/lib/kredis/types/callbacks.rb
@@ -1,18 +1,35 @@
 module Kredis::Types::Callbacks
   extend ActiveSupport::Concern
-  include ActiveSupport::Callbacks
 
-  included do
-    define_callbacks :change
+  module ClassMethods
+    def runs_callbacks_for(*method_names)
+      self.method_names = method_names
+    end
+  end
 
-    set_callback :change, :after do |object|
+  def self.prepended(base)
+    base.include ActiveSupport::Callbacks
+    base.cattr_accessor :method_names
+    base.define_callbacks :change
+
+    base.set_callback :change, :after do |object|
       @changed_callback&.call(object)
     end
   end
 
-  def initialize(redis, key, changed: ->(set){}, **options)
-    super redis, key, **options
+  def initialize(*args, **kwargs)
+    super(*args, **kwargs.except(:changed))
 
-    @changed_callback = changed
+    @changed_callback = kwargs[:changed]
+
+    singleton_class.class_eval do
+      method_names.each do |method_name|
+        define_method method_name do |*args, **kwargs|
+          run_callbacks :change do
+            super *args, **kwargs
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/kredis/types/callbacks.rb
+++ b/lib/kredis/types/callbacks.rb
@@ -1,0 +1,9 @@
+module Kredis::Types::Callbacks
+  extend ActiveSupport::Concern
+
+  def initialize(redis, key, changed: ->(set){}, **options)
+    super redis, key, **options
+
+    @changed_callback = changed
+  end
+end

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -1,7 +1,8 @@
 class Kredis::Types::List < Kredis::Types::Proxying
   proxying :lrange, :lrem, :lpush, :rpush
 
-  include Kredis::Types::Callbacks
+  prepend Kredis::Types::Callbacks
+  runs_callbacks_for :remove, :prepend, :append
 
   attr_accessor :typed
 
@@ -11,21 +12,15 @@ class Kredis::Types::List < Kredis::Types::Proxying
   alias to_a elements
 
   def remove(*elements)
-    run_callbacks :change do
-      types_to_strings(elements).each { |element| lrem 0, element }
-    end
+    types_to_strings(elements).each { |element| lrem 0, element }
   end
 
   def prepend(*elements)
-    run_callbacks :change do
-      lpush types_to_strings(elements) if elements.flatten.any?
-    end
+    lpush types_to_strings(elements) if elements.flatten.any?
   end
 
   def append(*elements)
-    run_callbacks :change do
-      rpush types_to_strings(elements) if elements.flatten.any?
-    end
+    rpush types_to_strings(elements) if elements.flatten.any?
   end
   alias << append
 end

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -1,6 +1,8 @@
 class Kredis::Types::List < Kredis::Types::Proxying
   proxying :lrange, :lrem, :lpush, :rpush
 
+  include Kredis::Types::Callbacks
+
   attr_accessor :typed
 
   def elements
@@ -9,15 +11,21 @@ class Kredis::Types::List < Kredis::Types::Proxying
   alias to_a elements
 
   def remove(*elements)
-    types_to_strings(elements).each { |element| lrem 0, element }
+    run_callbacks :change do
+      types_to_strings(elements).each { |element| lrem 0, element }
+    end
   end
 
   def prepend(*elements)
-    lpush types_to_strings(elements) if elements.flatten.any?
+    run_callbacks :change do
+      lpush types_to_strings(elements) if elements.flatten.any?
+    end
   end
 
   def append(*elements)
-    rpush types_to_strings(elements) if elements.flatten.any?
+    run_callbacks :change do
+      rpush types_to_strings(elements) if elements.flatten.any?
+    end
   end
   alias << append
 end

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -11,25 +11,25 @@ class Kredis::Types::Set < Kredis::Types::Proxying
   alias to_a members
 
   def add(*members)
-    sadd types_to_strings(members) if members.flatten.any?
-
-    @changed_callback&.call(self)
+    run_callbacks :change do
+      sadd types_to_strings(members) if members.flatten.any?
+    end
   end
   alias << add
 
   def remove(*members)
-    srem types_to_strings(members) if members.flatten.any?
-
-    @changed_callback&.call(self)
+    run_callbacks :change do
+      srem types_to_strings(members) if members.flatten.any?
+    end
   end
 
   def replace(*members)
-    multi do
-      del
-      add members
+    run_callbacks :change do
+      multi do
+        del
+        add members
+      end
     end
-
-    @changed_callback&.call(self)
   end
 
   def include?(member)

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -1,7 +1,8 @@
 class Kredis::Types::Set < Kredis::Types::Proxying
   proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop
 
-  include Kredis::Types::Callbacks
+  prepend Kredis::Types::Callbacks
+  runs_callbacks_for :add, :remove, :replace
 
   attr_accessor :typed
 
@@ -11,24 +12,18 @@ class Kredis::Types::Set < Kredis::Types::Proxying
   alias to_a members
 
   def add(*members)
-    run_callbacks :change do
-      sadd types_to_strings(members) if members.flatten.any?
-    end
+    sadd types_to_strings(members) if members.flatten.any?
   end
   alias << add
 
   def remove(*members)
-    run_callbacks :change do
-      srem types_to_strings(members) if members.flatten.any?
-    end
+    srem types_to_strings(members) if members.flatten.any?
   end
 
   def replace(*members)
-    run_callbacks :change do
-      multi do
-        del
-        add members
-      end
+    multi do
+      del
+      add members
     end
   end
 

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -1,6 +1,8 @@
 class Kredis::Types::Set < Kredis::Types::Proxying
   proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop
 
+  include Kredis::Types::Callbacks
+
   attr_accessor :typed
 
   def members
@@ -10,11 +12,15 @@ class Kredis::Types::Set < Kredis::Types::Proxying
 
   def add(*members)
     sadd types_to_strings(members) if members.flatten.any?
+
+    @changed_callback&.call(self)
   end
   alias << add
 
   def remove(*members)
     srem types_to_strings(members) if members.flatten.any?
+
+    @changed_callback&.call(self)
   end
 
   def replace(*members)
@@ -22,6 +28,8 @@ class Kredis::Types::Set < Kredis::Types::Proxying
       del
       add members
     end
+
+    @changed_callback&.call(self)
   end
 
   def include?(member)

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -1,7 +1,12 @@
 require "test_helper"
 
 class UniqueListTest < ActiveSupport::TestCase
-  setup { @list = Kredis.unique_list "myuniquelist" }
+  setup do
+    @list = Kredis.unique_list "myuniquelist"
+
+    @callback_mock = Minitest::Mock.new
+    @list_with_callback = Kredis.list "with_callback", changed: @callback_mock
+  end
 
   test "append" do
     @list.append(%w[ 1 2 3 ])
@@ -39,5 +44,19 @@ class UniqueListTest < ActiveSupport::TestCase
 
     @list.remove(2)
     assert_equal [ 1 ], @list.elements
+  end
+
+  test "append calls changed callback" do
+    @callback_mock.expect :call, nil, [@list_with_callback]
+    @list_with_callback.append(%w[ 1 2 3 ])
+
+    assert_mock @callback_mock
+  end
+
+  test "prepend calls changed callback" do
+    @callback_mock.expect :call, nil, [@list_with_callback]
+    @list_with_callback.prepend(%w[ 1 2 3 ])
+
+    assert_mock @callback_mock
   end
 end


### PR DESCRIPTION
Following up with #33, here's another take on the API.

The `Set` initializer is passed an (optional) `changed:` argument that can hold a lambda.

@dhh Obviously I'll wrap this in a more DRY abstraction, just wanted to check back if this POC aligns better with your concept of the library?

*Edit:* Uses `ActiveSupport::Callbacks` now ✌️