### PR TITLE
Provide factory method for vanilla kredis types

### DIFF
--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -70,17 +70,15 @@ module Kredis::Attributes
       def kredis_connection_with(method, name, key, **options)
         ivar_symbol = :"@#{name}_#{method}"
         type = method.to_s.sub("kredis_", "")
-        callback = options.delete(:after_change)
+        after_change = options.delete(:after_change)
 
         define_method(name) do
           if instance_variable_defined?(ivar_symbol)
             instance_variable_get(ivar_symbol)
           else
-            callbacks_proxy = Kredis::CallbacksProxy.new(
-              Kredis.send(type, kredis_key_evaluated(key) || kredis_key_for_attribute(name), **options),
-              self,
-              callback)
-            instance_variable_set(ivar_symbol, callbacks_proxy)
+            new_type = Kredis.send(type, kredis_key_evaluated(key) || kredis_key_for_attribute(name), **options)
+            instance_variable_set ivar_symbol,
+                                  after_change ? enrich_after_change_with_record_access(new_type, after_change) : new_type
           end
         end
       end
@@ -100,5 +98,12 @@ module Kredis::Attributes
 
     def extract_kredis_id
       try(:id) or raise NotImplementedError, "kredis needs a unique id, either implement an id method or pass a custom key."
+    end
+
+    def enrich_after_change_with_record_access(type, original_after_change)
+      case original_after_change
+      when Proc   then Kredis::CallbacksProxy.new(type, ->(_) { original_after_change.call(self) })
+      when Symbol then Kredis::CallbacksProxy.new(type, ->(_) { send(original_after_change) })
+      end
     end
 end

--- a/lib/kredis/callbacks_proxy.rb
+++ b/lib/kredis/callbacks_proxy.rb
@@ -22,7 +22,7 @@ class Kredis::CallbacksProxy
 
     if CALLBACK_OPERATIONS[@type.class]&.include? method
       if @callback.respond_to? :call
-        @callback.call(@record)
+        @callback.call(@record || @type)
       elsif @callback.is_a? Symbol
         @record.send(@callback)
       end

--- a/lib/kredis/callbacks_proxy.rb
+++ b/lib/kredis/callbacks_proxy.rb
@@ -14,19 +14,15 @@ class Kredis::CallbacksProxy
     Kredis::Types::Slots => %i[ reserve release reset ]
   }
 
-  def initialize(type, record, callback)
-    @type, @record, @callback = type, record, callback
+  def initialize(type, callback)
+    @type, @callback = type, callback
   end
 
   def method_missing(method, *args, **kwargs, &block)
     result = @type.send(method, *args, **kwargs, &block)
 
     if CALLBACK_OPERATIONS[@type.class]&.include? method
-      if @callback.respond_to? :call
-        @callback.call(@record || @type)
-      elsif @callback.is_a? Symbol
-        @record.send(@callback)
-      end
+      @callback.call(@type)
     end
 
     result

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -80,7 +80,7 @@ module Kredis::Types
   private
     def type_from(type_klass, config, key, after_change: nil, **options)
       type_klass.new(configured_for(config), namespaced_key(key), **options).then do |type|
-        after_change ? Kredis::CallbacksProxy.new(type, nil, after_change) : type
+        after_change ? Kredis::CallbacksProxy.new(type, after_change) : type
       end
     end
 end

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -1,87 +1,88 @@
 module Kredis::Types
-  def proxy(key, config: :shared)
-    Proxy.new configured_for(config), namespaced_key(key)
+  def proxy(key, config: :shared, after_change: nil)
+    type_from(Proxy, config, key, after_change: after_change)
   end
 
 
-  def scalar(key, typed: :string, default: nil, config: :shared)
-    Scalar.new configured_for(config), namespaced_key(key), typed: typed, default: default
+  def scalar(key, typed: :string, default: nil, config: :shared, after_change: nil)
+    type_from(Scalar, config, key, after_change: after_change, typed: typed, default: default)
   end
 
-  def string(key, default: nil, config: :shared)
-    Scalar.new configured_for(config), namespaced_key(key), typed: :string, default: default
+  def string(key, default: nil, config: :shared, after_change: nil)
+    type_from(Scalar, config, key, after_change: after_change, typed: :string, default: default)
   end
 
-  def integer(key, default: nil, config: :shared)
-    Scalar.new configured_for(config), namespaced_key(key), typed: :integer, default: default
+  def integer(key, default: nil, config: :shared, after_change: nil)
+    type_from(Scalar, config, key, after_change: after_change, typed: :integer, default: default)
   end
 
-  def decimal(key, default: nil, config: :shared)
-    Scalar.new configured_for(config), namespaced_key(key), typed: :decimal, default: default
+  def decimal(key, default: nil, config: :shared, after_change: nil)
+    type_from(Scalar, config, key, after_change: after_change, typed: :decimal, default: default)
   end
 
-  def float(key, default: nil, config: :shared)
-    Scalar.new configured_for(config), namespaced_key(key), typed: :float, default: default
+  def float(key, default: nil, config: :shared, after_change: nil)
+    type_from(Scalar, config, key, after_change: after_change, typed: :float, default: default)
   end
 
-  def boolean(key, default: nil, config: :shared)
-    Scalar.new configured_for(config), namespaced_key(key), typed: :boolean, default: default
+  def boolean(key, default: nil, config: :shared, after_change: nil)
+    type_from(Scalar, config, key, after_change: after_change, typed: :boolean, default: default)
   end
 
-  def datetime(key, default: nil, config: :shared)
-    Scalar.new configured_for(config), namespaced_key(key), typed: :datetime, default: default
+  def datetime(key, default: nil, config: :shared, after_change: nil)
+    type_from(Scalar, config, key, after_change: after_change, typed: :datetime, default: default)
   end
 
-  def json(key, default: nil, config: :shared)
-    Scalar.new configured_for(config), namespaced_key(key), typed: :json, default: default
-  end
-
-
-  def counter(key, expires_in: nil, config: :shared)
-    Counter.new configured_for(config), namespaced_key(key), expires_in: expires_in
-  end
-
-  def cycle(key, values:, expires_in: nil, config: :shared)
-    Cycle.new configured_for(config), namespaced_key(key), values: values, expires_in: expires_in
-  end
-
-  def flag(key, config: :shared)
-    Flag.new configured_for(config), namespaced_key(key)
-  end
-
-  def enum(key, values:, default:, config: :shared)
-    Enum.new configured_for(config), namespaced_key(key), values: values, default: default
-  end
-
-  def hash(key, typed: :string, config: :shared)
-    Hash.new configured_for(config), namespaced_key(key), typed: typed
-  end
-
-  def list(key, typed: :string, config: :shared)
-    List.new configured_for(config), namespaced_key(key), typed: typed
-  end
-
-  def unique_list(key, typed: :string, limit: nil, config: :shared)
-    UniqueList.new configured_for(config), namespaced_key(key), typed: typed, limit: limit
-  end
-
-  def set(key, typed: :string, config: :shared)
-    Set.new configured_for(config), namespaced_key(key), typed: typed
-  end
-
-  def slot(key, config: :shared)
-    Slots.new configured_for(config), namespaced_key(key), available: 1
-  end
-
-  def slots(key, available:, config: :shared)
-    Slots.new configured_for(config), namespaced_key(key), available: available
+  def json(key, default: nil, config: :shared, after_change: nil)
+    type_from(Scalar, config, key, after_change: after_change, typed: :json, default: default)
   end
 
 
-  def with_callback(type, key, **options)
-    callback = options.delete(:after_change)
-    Kredis::CallbacksProxy.new(Kredis.send(type, key, **options), nil, callback)
+  def counter(key, expires_in: nil, config: :shared, after_change: nil)
+    type_from(Counter, config, key, after_change: after_change, expires_in: expires_in)
   end
+
+  def cycle(key, values:, expires_in: nil, config: :shared, after_change: nil)
+    type_from(Cycle, config, key, after_change: after_change, values: values, expires_in: expires_in)
+  end
+
+  def flag(key, config: :shared, after_change: nil)
+    type_from(Flag, config, key, after_change: after_change)
+  end
+
+  def enum(key, values:, default:, config: :shared, after_change: nil)
+    type_from(Enum, config, key, after_change: after_change, values: values, default: default)
+  end
+
+  def hash(key, typed: :string, config: :shared, after_change: nil)
+    type_from(Hash, config, key, after_change: after_change, typed: typed)
+  end
+
+  def list(key, typed: :string, config: :shared, after_change: nil)
+    type_from(List, config, key, after_change: after_change, typed: typed)
+  end
+
+  def unique_list(key, typed: :string, limit: nil, config: :shared, after_change: nil)
+    type_from(UniqueList, config, key, after_change: after_change, typed: typed, limit: limit)
+  end
+
+  def set(key, typed: :string, config: :shared, after_change: nil)
+    type_from(Set, config, key, after_change: after_change, typed: typed)
+  end
+
+  def slot(key, config: :shared, after_change: nil)
+    type_from(Slots, config, key, after_change: after_change, available: 1)
+  end
+
+  def slots(key, available:, config: :shared, after_change: nil)
+    type_from(Slots, config, key, after_change: after_change, available: available)
+  end
+
+  private
+    def type_from(type_klass, config, key, after_change: nil, **options)
+      type_klass.new(configured_for(config), namespaced_key(key), **options).then do |type|
+        after_change ? Kredis::CallbacksProxy.new(type, nil, after_change) : type
+      end
+    end
 end
 
 require "kredis/types/proxy"

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -72,6 +72,12 @@ module Kredis::Types
   def slots(key, available:, config: :shared)
     Slots.new configured_for(config), namespaced_key(key), available: available
   end
+
+
+  def with_callback(type, key, **options)
+    callback = options.delete(:after_change)
+    Kredis::CallbacksProxy.new(Kredis.send(type, key, **options), nil, callback)
+  end
 end
 
 require "kredis/types/proxy"

--- a/test/attributes_callbacks_test.rb
+++ b/test/attributes_callbacks_test.rb
@@ -1,0 +1,144 @@
+require "test_helper"
+
+class Person
+  include Kredis::Attributes
+
+  kredis_list :names_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
+  kredis_list :names_with_method_callback, after_change: :changed
+  kredis_flag :special_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
+  kredis_flag :special_with_method_callback, after_change: :changed
+  kredis_string :address_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
+  kredis_string :address_with_method_callback, after_change: :changed
+  kredis_enum :morning_with_proc_callback, values: %w[ bright blue black ], default: "bright", after_change: ->(p) { p.callback_flag = true }
+  kredis_enum :morning_with_method_callback, values: %w[ bright blue black ], default: "bright", after_change: :changed
+  kredis_slot :attention_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
+  kredis_slot :attention_with_method_callback, after_change: :changed
+  kredis_set :vacations_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
+  kredis_set :vacations_with_method_callback, after_change: :changed
+  kredis_json :settings_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
+  kredis_json :settings_with_method_callback, after_change: :changed
+  kredis_counter :amount_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
+  kredis_counter :amount_with_method_callback, after_change: :changed
+
+  attr_accessor :callback_flag
+
+  def initialize
+    @callback_flag = false
+  end
+
+  def self.name
+    "Person"
+  end
+
+  def id
+    8
+  end
+
+  def changed
+    @callback_flag = true
+  end
+end
+
+class AttributesCallbacksTest < ActiveSupport::TestCase
+  setup do
+    @person = Person.new
+
+    refute @person.callback_flag
+  end
+
+  test "list with after_change proc callback" do
+    @person.names_with_proc_callback.append %w[ david kasper ]
+
+    assert @person.callback_flag
+  end
+
+  test "list with after_change method callback" do
+    @person.names_with_method_callback.append %w[ david kasper ]
+
+    assert @person.callback_flag
+  end
+
+  test "flag with after_change proc callback" do
+    @person.special_with_proc_callback.mark
+
+    assert @person.callback_flag
+  end
+
+  test "flag with after_change method callback" do
+    @person.special_with_method_callback.mark
+
+    assert @person.callback_flag
+  end
+
+  test "string with after_change proc callback" do
+    @person.address_with_proc_callback.value = "Copenhagen"
+
+    assert @person.callback_flag
+  end
+
+  test "string with after_change method callback" do
+    @person.address_with_proc_callback.value = "Copenhagen"
+
+    assert @person.callback_flag
+  end
+
+  test "slot with after_change proc callback" do
+    @person.attention_with_proc_callback.reserve
+
+    assert @person.callback_flag
+  end
+
+  test "slot with after_change method callback" do
+    @person.attention_with_method_callback.reserve
+
+    assert @person.callback_flag
+  end
+
+  test "enum with after_change proc callback" do
+    @person.morning_with_proc_callback.value = "blue"
+
+    assert @person.callback_flag
+  end
+
+  test "enum with after_change method callback" do
+    @person.morning_with_method_callback.value = "blue"
+
+    assert @person.callback_flag
+  end
+
+  test "set with after_change proc callback" do
+    @person.vacations_with_proc_callback.add "paris"
+
+    assert @person.callback_flag
+  end
+
+  test "set with after_change method callback" do
+    @person.vacations_with_method_callback.add "paris"
+
+    assert @person.callback_flag
+  end
+
+  test "json with after_change proc callback" do
+    @person.settings_with_proc_callback.value = { "color" => "red", "count" => 2 }
+
+    assert @person.callback_flag
+  end
+
+  test "json with after_change method callback" do
+    @person.settings_with_method_callback.value = { "color" => "red", "count" => 2 }
+
+    assert @person.callback_flag
+  end
+
+  test "counter with after_change proc callback" do
+    @person.amount_with_proc_callback.increment
+
+    assert @person.callback_flag
+  end
+
+  test "counter with after_change method callback" do
+    @person.amount_with_method_callback.increment
+
+    assert @person.callback_flag
+  end
+end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -1,144 +1,67 @@
 require "test_helper"
 
-class Person
-  include Kredis::Attributes
-
-  kredis_list :names_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
-  kredis_list :names_with_method_callback, after_change: :changed
-  kredis_flag :special_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
-  kredis_flag :special_with_method_callback, after_change: :changed
-  kredis_string :address_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
-  kredis_string :address_with_method_callback, after_change: :changed
-  kredis_enum :morning_with_proc_callback, values: %w[ bright blue black ], default: "bright", after_change: ->(p) { p.callback_flag = true }
-  kredis_enum :morning_with_method_callback, values: %w[ bright blue black ], default: "bright", after_change: :changed
-  kredis_slot :attention_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
-  kredis_slot :attention_with_method_callback, after_change: :changed
-  kredis_set :vacations_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
-  kredis_set :vacations_with_method_callback, after_change: :changed
-  kredis_json :settings_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
-  kredis_json :settings_with_method_callback, after_change: :changed
-  kredis_counter :amount_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
-  kredis_counter :amount_with_method_callback, after_change: :changed
-
-  attr_accessor :callback_flag
-
-  def initialize
-    @callback_flag = false
-  end
-
-  def self.name
-    "Person"
-  end
-
-  def id
-    8
-  end
-
-  def changed
-    @callback_flag = true
-  end
-end
-
 class CallbacksTest < ActiveSupport::TestCase
-  setup do
-    @person = Person.new
-
-    refute @person.callback_flag
-  end
-
   test "list with after_change proc callback" do
-    @person.names_with_proc_callback.append %w[ david kasper ]
+    @callback_check = nil
+    names = Kredis.with_callback :list, "names", after_change: ->(list) { @callback_check = list.elements }
+    names.append %w[ david kasper ]
 
-    assert @person.callback_flag
-  end
-
-  test "list with after_change method callback" do
-    @person.names_with_method_callback.append %w[ david kasper ]
-
-    assert @person.callback_flag
+    assert_equal %w[ david kasper ], @callback_check
   end
 
   test "flag with after_change proc callback" do
-    @person.special_with_proc_callback.mark
+    @callback_check = nil
+    special = Kredis.with_callback :flag, "special", after_change: ->(flag) { @callback_check = flag.marked? }
+    special.mark
 
-    assert @person.callback_flag
-  end
-
-  test "flag with after_change method callback" do
-    @person.special_with_method_callback.mark
-
-    assert @person.callback_flag
+    assert @callback_check
   end
 
   test "string with after_change proc callback" do
-    @person.address_with_proc_callback.value = "Copenhagen"
+    @callback_check = nil
+    address = Kredis.with_callback :string, "address", after_change: ->(scalar) { @callback_check = scalar.value }
+    address.value = "Copenhagen"
 
-    assert @person.callback_flag
-  end
-
-  test "string with after_change method callback" do
-    @person.address_with_proc_callback.value = "Copenhagen"
-
-    assert @person.callback_flag
+    assert_equal "Copenhagen", @callback_check
   end
 
   test "slot with after_change proc callback" do
-    @person.attention_with_proc_callback.reserve
+    @callback_check = true
+    attention = Kredis.with_callback :slot, "attention", after_change: ->(slot) { @callback_check = slot.available? }
+    attention.reserve
 
-    assert @person.callback_flag
-  end
-
-  test "slot with after_change method callback" do
-    @person.attention_with_method_callback.reserve
-
-    assert @person.callback_flag
+    refute @callback_check
   end
 
   test "enum with after_change proc callback" do
-    @person.morning_with_proc_callback.value = "blue"
+    @callback_check = nil
+    morning = Kredis.with_callback :enum, "morning", values: %w[ bright blue black ], default: "bright", after_change: ->(enum) { @callback_check = enum.value }
+    morning.value = "blue"
 
-    assert @person.callback_flag
-  end
-
-  test "enum with after_change method callback" do
-    @person.morning_with_method_callback.value = "blue"
-
-    assert @person.callback_flag
+    assert_equal "blue", @callback_check
   end
 
   test "set with after_change proc callback" do
-    @person.vacations_with_proc_callback.add "paris"
+    @callback_check = nil
+    vacations = Kredis.with_callback :set, "vacations", after_change: ->(set) { @callback_check = set.members }
+    vacations.add "paris"
 
-    assert @person.callback_flag
-  end
-
-  test "set with after_change method callback" do
-    @person.vacations_with_method_callback.add "paris"
-
-    assert @person.callback_flag
+    assert_equal ["paris"], @callback_check
   end
 
   test "json with after_change proc callback" do
-    @person.settings_with_proc_callback.value = { "color" => "red", "count" => 2 }
+    @callback_check = nil
+    settings = Kredis.with_callback :json, "settings", after_change: ->(json) { @callback_check = settings.value }
+    settings.value = { "color" => "red", "count" => 2 }
 
-    assert @person.callback_flag
-  end
-
-  test "json with after_change method callback" do
-    @person.settings_with_method_callback.value = { "color" => "red", "count" => 2 }
-
-    assert @person.callback_flag
+    assert_equal ({ "color" => "red", "count" => 2 }), @callback_check
   end
 
   test "counter with after_change proc callback" do
-    @person.amount_with_proc_callback.increment
+    @callback_check = nil
+    amount = Kredis.with_callback :counter, "amount", after_change: ->(counter) { @callback_check = counter.value }
+    amount.increment
 
-    assert @person.callback_flag
-  end
-
-  test "counter with after_change method callback" do
-    @person.amount_with_method_callback.increment
-
-    assert @person.callback_flag
+    assert_equal 1, @callback_check
   end
 end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class CallbacksTest < ActiveSupport::TestCase
   test "list with after_change proc callback" do
     @callback_check = nil
-    names = Kredis.with_callback :list, "names", after_change: ->(list) { @callback_check = list.elements }
+    names = Kredis.list "names", after_change: ->(list) { @callback_check = list.elements }
     names.append %w[ david kasper ]
 
     assert_equal %w[ david kasper ], @callback_check
@@ -11,7 +11,7 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "flag with after_change proc callback" do
     @callback_check = nil
-    special = Kredis.with_callback :flag, "special", after_change: ->(flag) { @callback_check = flag.marked? }
+    special = Kredis.flag "special", after_change: ->(flag) { @callback_check = flag.marked? }
     special.mark
 
     assert @callback_check
@@ -19,7 +19,7 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "string with after_change proc callback" do
     @callback_check = nil
-    address = Kredis.with_callback :string, "address", after_change: ->(scalar) { @callback_check = scalar.value }
+    address = Kredis.string "address", after_change: ->(scalar) { @callback_check = scalar.value }
     address.value = "Copenhagen"
 
     assert_equal "Copenhagen", @callback_check
@@ -27,7 +27,7 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "slot with after_change proc callback" do
     @callback_check = true
-    attention = Kredis.with_callback :slot, "attention", after_change: ->(slot) { @callback_check = slot.available? }
+    attention = Kredis.slot "attention", after_change: ->(slot) { @callback_check = slot.available? }
     attention.reserve
 
     refute @callback_check
@@ -35,7 +35,7 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "enum with after_change proc callback" do
     @callback_check = nil
-    morning = Kredis.with_callback :enum, "morning", values: %w[ bright blue black ], default: "bright", after_change: ->(enum) { @callback_check = enum.value }
+    morning = Kredis.enum "morning", values: %w[ bright blue black ], default: "bright", after_change: ->(enum) { @callback_check = enum.value }
     morning.value = "blue"
 
     assert_equal "blue", @callback_check
@@ -43,7 +43,7 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "set with after_change proc callback" do
     @callback_check = nil
-    vacations = Kredis.with_callback :set, "vacations", after_change: ->(set) { @callback_check = set.members }
+    vacations = Kredis.set "vacations", after_change: ->(set) { @callback_check = set.members }
     vacations.add "paris"
 
     assert_equal ["paris"], @callback_check
@@ -51,7 +51,7 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "hash with after_change proc callback" do
     @callback_check = nil
-    high_scores = Kredis.with_callback :hash, "high_scores", typed: :integer, after_change: ->(hash) { @callback_check = hash.entries }
+    high_scores = Kredis.hash "high_scores", typed: :integer, after_change: ->(hash) { @callback_check = hash.entries }
     high_scores.update(space_invaders: 100, pong: 42)
 
     assert_equal({ "space_invaders" => 100, "pong" => 42 }, @callback_check)
@@ -59,7 +59,7 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "json with after_change proc callback" do
     @callback_check = nil
-    settings = Kredis.with_callback :json, "settings", after_change: ->(json) { @callback_check = settings.value }
+    settings = Kredis.json "settings", after_change: ->(json) { @callback_check = settings.value }
     settings.value = { "color" => "red", "count" => 2 }
 
     assert_equal ({ "color" => "red", "count" => 2 }), @callback_check
@@ -67,7 +67,7 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "counter with after_change proc callback" do
     @callback_check = nil
-    amount = Kredis.with_callback :counter, "amount", after_change: ->(counter) { @callback_check = counter.value }
+    amount = Kredis.counter "amount", after_change: ->(counter) { @callback_check = counter.value }
     amount.increment
 
     assert_equal 1, @callback_check

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -49,6 +49,14 @@ class CallbacksTest < ActiveSupport::TestCase
     assert_equal ["paris"], @callback_check
   end
 
+  test "hash with after_change proc callback" do
+    @callback_check = nil
+    high_scores = Kredis.with_callback :hash, "high_scores", typed: :integer, after_change: ->(hash) { @callback_check = hash.entries }
+    high_scores.update(space_invaders: 100, pong: 42)
+
+    assert_equal({ "space_invaders" => 100, "pong" => 42 }, @callback_check)
+  end
+
   test "json with after_change proc callback" do
     @callback_check = nil
     settings = Kredis.with_callback :json, "settings", after_change: ->(json) { @callback_check = settings.value }


### PR DESCRIPTION
Building up on #35, I just wanted to quickly PR the factory method for vanilla types as mentioned in the PR comments, to address @leastbad's and others' concerns.

The only meaningful changes are:
1. a new factory method `Kredis.with_callback` that you can pass a type as a symbol, plus key, arguments, and callback,
2. the proc is now called with `@record || @type`, making sure that if not being instantiated from an ActiveRecord object, it's passing the kredis type back to the lambda as an argument.