### PR TITLE
Implement basic hash functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ hash.set("key" => "value", "key2" => "value2")        # => HSET myhash "key", "v
 %w[ key key2 ] == hash.keys                           # => HKEYS myhash
 %w[ value value2 ] == hash.values                     # => HVALS myhash
 
+high_scores = Kredis.hash "high_scores"
+high_scores.set(space_invaders: 100, pong: 42)                # HSET high_scores "space_invaders", "100", "pong", "42"
+%w[ space_invaders pong ] == high_scores.keys                 # HKEYS high_scores
+[100, 42] == high_scores.values                               # HVALS high_scores
+{ "space_invaders" => 100, "pong" => 42 } == high_scores.to_h # HGETALL high_scores
+
 head_count = Kredis.counter "headcount"
 0 == head_count.value              # => GET "headcount"
 head_count.increment               # => SET headcount 0 NX + INCRBY headcount 1

--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -62,6 +62,10 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, config: config, after_change: after_change
     end
 
+    def kredis_hash(name, key: nil, typed: :string, config: :shared, after_change: nil)
+      kredis_connection_with __method__, name, key, typed: typed, config: config, after_change: after_change
+    end
+
     private
       def kredis_connection_with(method, name, key, **options)
         ivar_symbol = :"@#{name}_#{method}"

--- a/lib/kredis/callbacks_proxy.rb
+++ b/lib/kredis/callbacks_proxy.rb
@@ -7,6 +7,7 @@ class Kredis::CallbacksProxy
     Kredis::Types::Cycle => %i[ next ],
     Kredis::Types::Enum => %i[ value= reset ],
     Kredis::Types::Flag => %i[ mark remove ],
+    Kredis::Types::Hash => %i[ set ],
     Kredis::Types::List => %i[ remove prepend append ],
     Kredis::Types::Scalar => %i[ value= clear ],
     Kredis::Types::Set => %i[ add remove replace take clear ],

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -53,6 +53,10 @@ module Kredis::Types
     Enum.new configured_for(config), namespaced_key(key), values: values, default: default
   end
 
+  def hash(key, typed: :string, config: :shared)
+    Hash.new configured_for(config), namespaced_key(key), typed: typed
+  end
+
   def list(key, typed: :string, config: :shared)
     List.new configured_for(config), namespaced_key(key), typed: typed
   end
@@ -82,6 +86,7 @@ require "kredis/types/counter"
 require "kredis/types/cycle"
 require "kredis/types/flag"
 require "kredis/types/enum"
+require "kredis/types/hash"
 require "kredis/types/list"
 require "kredis/types/unique_list"
 require "kredis/types/set"

--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -1,10 +1,12 @@
+require "active_support/core_ext/hash"
+
 class Kredis::Types::Hash < Kredis::Types::Proxying
   proxying :hset, :hmget, :hgetall, :hdel, :hkeys, :hvals
 
   attr_accessor :typed
 
   def entries
-    (hgetall || {}).transform_values { |val| string_to_type(val, typed) }
+    (hgetall || {}).transform_values { |val| string_to_type(val, typed) }.with_indifferent_access
   end
   alias to_h entries
 

--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -1,0 +1,27 @@
+class Kredis::Types::Hash < Kredis::Types::Proxying
+  proxying :hset, :hmget, :hgetall, :hkeys, :hvals
+
+  attr_accessor :typed
+
+  def entries
+    Hash[*strings_to_types(hgetall || {}, typed)]
+  end
+  alias to_h entries
+
+  def set(**entries)
+    hset types_to_strings(entries) if entries.flatten.any?
+  end
+
+  def get(*keys)
+    values = strings_to_types(hmget(keys) || [], typed)
+    values.size == 1 ? values.first : values
+  end
+
+  def keys
+    strings_to_types(hkeys || [], typed)
+  end
+
+  def values
+    strings_to_types(hvals || [], typed)
+  end
+end

--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -1,5 +1,5 @@
 class Kredis::Types::Hash < Kredis::Types::Proxying
-  proxying :hset, :hmget, :hgetall, :hkeys, :hvals
+  proxying :hset, :hmget, :hgetall, :hdel, :hkeys, :hvals
 
   attr_accessor :typed
 
@@ -15,6 +15,10 @@ class Kredis::Types::Hash < Kredis::Types::Proxying
   def get(*keys)
     values = strings_to_types(hmget(keys) || [], typed)
     values.size == 1 ? values.first : values
+  end
+
+  def del(*keys)
+    hdel types_to_strings(keys) if keys.flatten.any?
   end
 
   def keys

--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -4,7 +4,7 @@ class Kredis::Types::Hash < Kredis::Types::Proxying
   attr_accessor :typed
 
   def entries
-    Hash[*strings_to_types(hgetall || {}, typed)]
+    (hgetall || {}).transform_values { |val| string_to_type(val, typed) }
   end
   alias to_h entries
 
@@ -22,7 +22,7 @@ class Kredis::Types::Hash < Kredis::Types::Proxying
   end
 
   def keys
-    strings_to_types(hkeys || [], typed)
+    hkeys || []
   end
 
   def values

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -20,6 +20,7 @@ class Person
   kredis_set :vacations
   kredis_json :settings
   kredis_counter :amount
+  kredis_hash :high_scores
 
   def self.name
     "Person"
@@ -198,6 +199,13 @@ class AttributesTest < ActiveSupport::TestCase
     assert_equal 1, @person.amount.value
     @person.amount.decrement
     assert_equal 0, @person.amount.value
+  end
+
+  test "hash" do
+    @person.high_scores.set(space_invaders: 100, pong: 42)
+    assert_equal({"space_invaders" => "100", "pong" => "42"}, @person.high_scores.to_h)
+    assert_equal(["space_invaders", "pong"], @person.high_scores.keys)
+    assert_equal(["100", "42"], @person.high_scores.values)
   end
 
   test "missing id to constrain key" do

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -20,7 +20,7 @@ class Person
   kredis_set :vacations
   kredis_json :settings
   kredis_counter :amount
-  kredis_hash :high_scores
+  kredis_hash :high_scores, typed: :integer
 
   def self.name
     "Person"
@@ -203,9 +203,9 @@ class AttributesTest < ActiveSupport::TestCase
 
   test "hash" do
     @person.high_scores.set(space_invaders: 100, pong: 42)
-    assert_equal({"space_invaders" => "100", "pong" => "42"}, @person.high_scores.to_h)
-    assert_equal(["space_invaders", "pong"], @person.high_scores.keys)
-    assert_equal(["100", "42"], @person.high_scores.values)
+    assert_equal({ "space_invaders" => 100, "pong" => 42 }, @person.high_scores.to_h) 
+    assert_equal([ "space_invaders", "pong" ], @person.high_scores.keys)
+    assert_equal([ 100, 42 ], @person.high_scores.values)
   end
 
   test "missing id to constrain key" do

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -19,6 +19,8 @@ class Person
   kredis_json :settings_with_method_callback, after_change: :changed
   kredis_counter :amount_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
   kredis_counter :amount_with_method_callback, after_change: :changed
+  kredis_hash :high_scores_with_proc_callback, after_change: ->(p) { p.callback_flag = true }
+  kredis_hash :high_scores_with_method_callback, after_change: :changed
 
   attr_accessor :callback_flag
 
@@ -138,6 +140,18 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "counter with after_change method callback" do
     @person.amount_with_method_callback.increment
+
+    assert @person.callback_flag
+  end
+
+  test "hash with after_change proc callback" do
+    @person.high_scores_with_proc_callback.set(space_invaders: 100, pong: 42) 
+
+    assert @person.callback_flag
+  end
+
+  test "hash with after_change method callback" do
+    @person.high_scores_with_method_callback.set(space_invaders: 100, pong: 42) 
 
     assert @person.callback_flag
   end

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -38,4 +38,14 @@ class HashTest < ActiveSupport::TestCase
     @hash.set("key2" => "value2", "key3" => "value3")
     assert_equal %w[ value value2 value3 ], @hash.values
   end
+
+  test "typed as integer" do
+    @hash = Kredis.hash "myhash", typed: :integer
+    @hash.set(space_invaders: 100, pong: 42)
+
+    assert_equal(%w[ space_invaders pong ], @hash.keys)
+    assert_equal([100, 42], @hash.values)
+    assert_equal(100, @hash.get(:space_invaders))
+    assert_equal({ "space_invaders" => 100, "pong" => 42 }, @hash.to_h)
+  end
 end

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -18,6 +18,15 @@ class HashTest < ActiveSupport::TestCase
     assert_nil @hash.get("key")
   end
 
+  test "del" do
+    @hash.set(key: :value)
+    @hash.set("key2" => "value2", "key3" => "value3")
+    assert_equal({ "key" => "value", "key2" => "value2", "key3" => "value3" }, @hash.to_h)
+
+    @hash.del("key", "key2")
+    assert_equal({ "key3" => "value3" }, @hash.to_h)
+  end
+
   test "keys" do
     @hash.set(key: :value)
     @hash.set("key2" => "value2", "key3" => "value3")

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "active_support/core_ext/integer"
+
+class HashTest < ActiveSupport::TestCase
+  setup { @hash = Kredis.hash "myhash" }
+
+  test "set" do
+    @hash.set(key: :value)
+    @hash.set("key2" => "value2", "key3" => "value3")
+    assert_equal({ "key" => "value", "key2" => "value2", "key3" => "value3" }, @hash.to_h)
+  end
+
+  test "get" do
+    @hash.set("key2" => "value2", "key3" => "value3")
+    assert_equal "value2", @hash.get("key2")
+    assert_equal "value3", @hash.get("key3")
+    assert_equal %w[ value2 value3 ], @hash.get("key2", "key3")
+    assert_nil @hash.get("key")
+  end
+
+  test "keys" do
+    @hash.set(key: :value)
+    @hash.set("key2" => "value2", "key3" => "value3")
+    assert_equal %w[ key key2 key3 ], @hash.keys
+  end
+
+  test "values" do
+    @hash.set(key: :value)
+    @hash.set("key2" => "value2", "key3" => "value3")
+    assert_equal %w[ value value2 value3 ], @hash.values
+  end
+end

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -13,7 +13,7 @@ class HashTest < ActiveSupport::TestCase
   test "get" do
     @hash.set("key2" => "value2", "key3" => "value3")
     assert_equal "value2", @hash.get("key2")
-    assert_equal "value3", @hash.get("key3")
+    assert_equal "value3", @hash.get(:key3)
     assert_equal %w[ value2 value3 ], @hash.get("key2", "key3")
     assert_nil @hash.get("key")
   end
@@ -46,6 +46,7 @@ class HashTest < ActiveSupport::TestCase
     assert_equal(%w[ space_invaders pong ], @hash.keys)
     assert_equal([100, 42], @hash.values)
     assert_equal(100, @hash.get(:space_invaders))
+    assert_equal(42, @hash.get("pong"))
     assert_equal({ "space_invaders" => 100, "pong" => 42 }, @hash.to_h)
   end
 end


### PR DESCRIPTION
This PR introduces basic Redis native hash functionality to kredis. It proxies the following methods:

- `entries` => `hgetall`
- `set` => `hset`
- `get` => `hmget`, returning an array of values or a single value
- `keys` => `hkeys`
- `values`=> `hvals`

Note that all keys and values are treated as strings for now.

Closes #28 