### PR TITLE
Add remove method to hash type

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ hash.update("key" => "value", "key2" => "value2")     # => HSET myhash "key", "v
 "value2" == hash["key2"]                              # => HMGET myhash "key2"
 %w[ key key2 ] == hash.keys                           # => HKEYS myhash
 %w[ value value2 ] == hash.values                     # => HVALS myhash
+hash.remove                                           # => DEL myhash
 
 high_scores = Kredis.hash "high_scores", typed: :integer
 high_scores.update(space_invaders: 100, pong: 42)             # HSET high_scores "space_invaders", "100", "pong", "42"

--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -1,7 +1,7 @@
 require "active_support/core_ext/hash"
 
 class Kredis::Types::Hash < Kredis::Types::Proxying
-  proxying :hget, :hset, :hmget, :hdel, :hgetall, :hkeys, :hvals
+  proxying :hget, :hset, :hmget, :hdel, :hgetall, :hkeys, :hvals, :del
 
   attr_accessor :typed
 
@@ -26,6 +26,9 @@ class Kredis::Types::Hash < Kredis::Types::Proxying
     hdel types_to_strings(keys) if keys.flatten.any?
   end
 
+  def remove
+    del 
+  end
 
   def entries
     (hgetall || {}).transform_values { |val| string_to_type(val, typed) }.with_indifferent_access

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -69,4 +69,11 @@ class HashTest < ActiveSupport::TestCase
     assert_equal 42, @hash["pong"]
     assert_equal({ "space_invaders" => 100, "pong" => 42 }, @hash.to_h)
   end
+
+  test "remove" do
+    @hash.update("key2" => "value2")
+    assert_equal "value2", @hash["key2"]
+    @hash.remove
+    assert_equal({}, @hash.to_h)
+  end
 end


### PR DESCRIPTION
There was no way to delete a hash. This PR creates the `remove` method so that this works:
```ruby
hash = Kredis.hash "myhash"
hash.remove
```
This method calls `DEL myhash` in Redis

