### PR TITLE
Bring expires_in configuration to Kredis::Attributes

### DIFF
--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -6,20 +6,20 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, config: config, after_change: after_change
     end
 
-    def kredis_string(name, key: nil, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, config: config, after_change: after_change
+    def kredis_string(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_integer(name, key: nil, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, config: config, after_change: after_change
+    def kredis_integer(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_decimal(name, key: nil, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, config: config, after_change: after_change
+    def kredis_decimal(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_datetime(name, key: nil, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, config: config, after_change: after_change
+    def kredis_datetime(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
     end
 
     def kredis_flag(name, key: nil, config: :shared, after_change: nil)
@@ -30,16 +30,16 @@ module Kredis::Attributes
       end
     end
 
-    def kredis_float(name, key: nil, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, config: config, after_change: after_change
+    def kredis_float(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
     end
 
     def kredis_enum(name, key: nil, values:, default:, config: :shared, after_change: nil)
       kredis_connection_with __method__, name, key, values: values, default: default, config: config, after_change: after_change
     end
 
-    def kredis_json(name, key: nil, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, config: config, after_change: after_change
+    def kredis_json(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
     end
 
     def kredis_list(name, key: nil, typed: :string, config: :shared, after_change: nil)

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "active_support/core_ext/integer"
 
 class Person
   include Kredis::Attributes
@@ -21,6 +22,7 @@ class Person
   kredis_set :vacations
   kredis_json :settings
   kredis_counter :amount
+  kredis_string :temporary_password, expires_in: 1.second
   kredis_hash :high_scores, typed: :integer
 
   def self.name
@@ -226,5 +228,12 @@ class AttributesTest < ActiveSupport::TestCase
     def suddenly_implemented_person.id; 8; end
 
     assert_nil suddenly_implemented_person.anything.get
+  end
+
+  test "expiring scalars" do
+    @person.temporary_password.value = "assigned"
+    assert_changes "@person.temporary_password.value", from: "assigned", to: nil do
+      sleep 1.1.seconds
+    end
   end
 end


### PR DESCRIPTION
Expiring scalars came to Kredis in #19. The expiration configuration was available when working directly with types, but was not made available when defining Kredis values on an `ActiveRecord`/`ActiveModel` class. This change makes the `expires_in` option available when working with scalars on `ActiveRecord/ActiveModel`.