### PR TITLE
Add native nokogiri to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.2-x86_64-darwin)
       racc (~> 1.4)
     racc (1.5.2)
@@ -140,6 +142,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-20
   ruby
   x86_64-darwin-20
 


### PR DESCRIPTION
I needed this in Gemfile.lock to get native nokogiri gem please.

Without this PR, `nokogiri` tries to install itself from source, even though a native version is already installed. And on my mac it's failing and I'm not in the mood to debug it lol

```
Running 'configure' for libxml2 2.9.10... ERROR, review
'/Users/drnic/.rvm/gems/ruby-3.0.2/gems/nokogiri-1.11.2/ext/nokogiri/tmp/arm64-apple-darwin20/ports/libxml2/2.9.10/configure.log' to see what happened. Last
lines are:
========================================================================
checking whether to enable maintainer-specific portions of Makefiles... yes
checking build system type... arm-apple-darwin20.6.0
checking host system type... Invalid configuration `arm64-apple-darwin20': machine `arm64-apple' not recognized
configure: error: /bin/sh ./config.sub arm64-apple-darwin20 failed
========================================================================
```