### PR TITLE
Add option to configure how the redis client is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,16 @@ Kredis::Connections.connections[:shared] = Redis.new(
 
 The above code could be added to either `config/environments/production.rb` or an initializer. Please ensure that your client private key, if used, is stored your credentials file or another secure location.
 
+### Configure how the redis client is created
+
+You can configure how the redis client is created by setting `config.connector` in your `application.rb`:
+
+```ruby
+config.kredis.connector = ->(config) { SomeRedisProxy.new(config) }
+```
+
+By default Kredis will use `Redis.new(config)`.
+
 ## License
 
 Kredis is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/kredis/connections.rb
+++ b/lib/kredis/connections.rb
@@ -3,7 +3,7 @@ require "redis"
 module Kredis::Connections
   mattr_accessor :connections, default: Hash.new
   mattr_accessor :configurator
-  mattr_accessor :connector, default: ->(config){ Redis.new(config) }
+  mattr_accessor :connector, default: ->(config) { Redis.new(config) }
 
   def configured_for(name)
     connections[name] ||= begin

--- a/lib/kredis/connections.rb
+++ b/lib/kredis/connections.rb
@@ -3,11 +3,12 @@ require "redis"
 module Kredis::Connections
   mattr_accessor :connections, default: Hash.new
   mattr_accessor :configurator
+  mattr_accessor :connector, default: ->(config){ Redis.new(config) }
 
   def configured_for(name)
     connections[name] ||= begin
       Kredis.instrument :meta, message: "Connected to #{name}" do
-        Redis.new configurator.config_for("redis/#{name}")
+        connector.call configurator.config_for("redis/#{name}")
       end
     end
   end

--- a/lib/kredis/railtie.rb
+++ b/lib/kredis/railtie.rb
@@ -13,7 +13,7 @@ class Kredis::Railtie < ::Rails::Railtie
   end
 
   initializer "kredis.configuration" do
-    Kredis::Connections.connector = config.kredis.connector || ->(config){ Redis.new(config) }
+    Kredis::Connections.connector = config.kredis.connector || ->(config) { Redis.new(config) }
   end
 
   initializer "kredis.configurator" do

--- a/lib/kredis/railtie.rb
+++ b/lib/kredis/railtie.rb
@@ -12,6 +12,10 @@ class Kredis::Railtie < ::Rails::Railtie
     Kredis::LogSubscriber.logger = config.kredis.logger || Rails.logger
   end
 
+  initializer "kredis.configuration" do
+    Kredis::Connections.connector = config.kredis.connector || ->(config){ Redis.new(config) }
+  end
+
   initializer "kredis.configurator" do
     Kredis.configurator = Rails.application
   end


### PR DESCRIPTION
This adds a new option `config.kredis.connector` to customize how the `redis` client is created.

An example where this would be useful is configuring a proxy that wraps the Redis connection to provide failover capabilities (e.g: using makara).

cc @dhh
