### PR TITLE
Change default test suite db to 1

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ require "byebug"
 
 require "kredis"
 
-Kredis.configurator = Class.new { def config_for(name) {} end }.new
+Kredis.configurator = Class.new { def config_for(name) { db: "15" } end }.new
 
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ require "byebug"
 
 require "kredis"
 
-Kredis.configurator = Class.new { def config_for(name) { db: "15" } end }.new
+Kredis.configurator = Class.new { def config_for(name) { db: "1" } end }.new
 
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 


### PR DESCRIPTION
I reckon the `15` db is the least likely one to be in use, so setting the test suite to use that by default.

Closes https://github.com/rails/kredis/issues/48