### PR TITLE
Add support for the NX (not exists) option to flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ true == flag.marked?            # => EXISTS myflag
 flag.remove                     # => DEL myflag  
 false == flag.marked?           # => EXISTS myflag
 
-true == flag.mark(expires_in: 1.second, unless_exists: true)    #=> SET myflag 1 EX 1 NX
-false == flag.mark(expires_in: 10.seconds, unless_exists: true) #=> SET myflag 10 EX 1 NX
+true == flag.mark(expires_in: 1.second, force: false)    #=> SET myflag 1 EX 1 NX
+false == flag.mark(expires_in: 10.seconds, force: false) #=> SET myflag 10 EX 1 NX
 true == flag.marked?            #=> EXISTS myflag
 sleep 0.5.seconds
 true == flag.marked?            #=> EXISTS myflag

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ true == flag.marked?            # => EXISTS myflag
 flag.remove                     # => DEL myflag  
 false == flag.marked?           # => EXISTS myflag
 
-flag.mark(expires_in: 1.second) #=> SET myflag 1 EX 1
+true == flag.mark(expires_in: 1.second, unless_exists: true)    #=> SET myflag 1 EX 1 NX
+false == flag.mark(expires_in: 10.seconds, unless_exists: true) #=> SET myflag 10 EX 1 NX
 true == flag.marked?            #=> EXISTS myflag
 sleep 0.5.seconds
 true == flag.marked?            #=> EXISTS myflag

--- a/lib/kredis/types/flag.rb
+++ b/lib/kredis/types/flag.rb
@@ -3,8 +3,8 @@ class Kredis::Types::Flag < Kredis::Types::Proxying
 
   attr_accessor :expires_in
 
-  def mark(expires_in: nil)
-    set 1, ex: expires_in || self.expires_in
+  def mark(expires_in: nil, force: true)
+    set 1, ex: expires_in || self.expires_in, nx: !force
   end
 
   def marked?

--- a/lib/kredis/version.rb
+++ b/lib/kredis/version.rb
@@ -1,3 +1,3 @@
 module Kredis
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/lib/kredis/version.rb
+++ b/lib/kredis/version.rb
@@ -1,3 +1,3 @@
 module Kredis
-  VERSION = "0.4.1"
+  VERSION = "0.4.0"
 end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -244,4 +244,15 @@ class AttributesTest < ActiveSupport::TestCase
       sleep 1.1.seconds
     end
   end
+
+  test "expiring flag with force" do
+    assert @person.temporary_special.mark
+
+    sleep 0.5.seconds
+    assert_not @person.temporary_special.mark(force: false)
+
+    assert_changes "@person.temporary_special.marked?", from: true, to: false do
+      sleep 0.6.seconds
+    end
+  end
 end

--- a/test/types/flag_test.rb
+++ b/test/types/flag_test.rb
@@ -24,11 +24,11 @@ class FlagTest < ActiveSupport::TestCase
     assert_not @flag.marked?
   end
 
-  test "mark unless exists" do
-    assert @flag.mark(expires_in: 1.second, unless_exists: true)
+  test "mark with force" do
+    assert @flag.mark(expires_in: 1.second, force: false)
     assert @flag.mark(expires_in: 1.second)
-    assert @flag.mark(expires_in: 1.second, unless_exists: false)
-    assert_not @flag.mark(expires_in: 10.seconds, unless_exists: true)
+    assert @flag.mark(expires_in: 1.second, force: true)
+    assert_not @flag.mark(expires_in: 10.seconds, force: false)
 
     assert @flag.marked?
 

--- a/test/types/flag_test.rb
+++ b/test/types/flag_test.rb
@@ -23,4 +23,19 @@ class FlagTest < ActiveSupport::TestCase
     sleep 0.6.seconds
     assert_not @flag.marked?
   end
+
+  test "mark unless exists" do
+    assert @flag.mark(expires_in: 1.second, unless_exists: true)
+    assert @flag.mark(expires_in: 1.second)
+    assert @flag.mark(expires_in: 1.second, unless_exists: false)
+    assert_not @flag.mark(expires_in: 10.seconds, unless_exists: true)
+
+    assert @flag.marked?
+
+    sleep 0.5.seconds
+    assert @flag.marked?
+
+    sleep 0.6.seconds
+    assert_not @flag.marked?
+  end
 end


### PR DESCRIPTION
There are some Flag usage [Redis patterns](https://redis.io/commands/set#patterns) that benefit from having the flag set only if doesn't exist. SET support that use case with the `NX` option.