### PR TITLE
Set flag expiration on attribute specification

### DIFF
--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -22,8 +22,8 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_flag(name, key: nil, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, config: config, after_change: after_change
+    def kredis_flag(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
 
       define_method("#{name}?") do
         send(name).marked?

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -47,8 +47,8 @@ module Kredis::Types
     type_from(Cycle, config, key, after_change: after_change, values: values, expires_in: expires_in)
   end
 
-  def flag(key, config: :shared, after_change: nil)
-    type_from(Flag, config, key, after_change: after_change)
+  def flag(key, config: :shared, after_change: nil, expires_in: nil)
+    type_from(Flag, config, key, after_change: after_change, expires_in: expires_in)
   end
 
   def enum(key, values:, default:, config: :shared, after_change: nil)

--- a/lib/kredis/types/flag.rb
+++ b/lib/kredis/types/flag.rb
@@ -1,8 +1,10 @@
 class Kredis::Types::Flag < Kredis::Types::Proxying
   proxying :set, :exists?, :del
 
+  attr_accessor :expires_in
+
   def mark(expires_in: nil)
-    set 1, ex: expires_in
+    set 1, ex: expires_in || self.expires_in
   end
 
   def marked?

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -11,6 +11,7 @@ class Person
   kredis_list :names_with_custom_key, key: ->(p) { "person:#{p.id}:names_customized" }
   kredis_unique_list :skills, limit: 2
   kredis_flag :special
+  kredis_flag :temporary_special, expires_in: 1.second
   kredis_string :address
   kredis_integer :age
   kredis_decimal :salary
@@ -233,6 +234,13 @@ class AttributesTest < ActiveSupport::TestCase
   test "expiring scalars" do
     @person.temporary_password.value = "assigned"
     assert_changes "@person.temporary_password.value", from: "assigned", to: nil do
+      sleep 1.1.seconds
+    end
+  end
+
+  test "expiring flag" do
+    @person.temporary_special.mark
+    assert_changes "@person.temporary_special.marked?", from: true, to: false do
       sleep 1.1.seconds
     end
   end


### PR DESCRIPTION
So you can do:

```ruby
class User
  kredis_flag :banned, expires_in: 2.days
end

user.banned.mark
```

Instead of having to pass in the `expires_in` at multiple call sites. This matches what we already have for scalars.