### PR TITLE
Appending to unique list with limit should trim from the end

### DIFF
--- a/lib/kredis/types/unique_list.rb
+++ b/lib/kredis/types/unique_list.rb
@@ -16,7 +16,7 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     multi do
       remove elements
       super
-      ltrim (limit - 1), -1 if limit
+      ltrim -limit, -1 if limit
     end if Array(elements).flatten.any?
   end
   alias << append

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class UniqueListTest < ActiveSupport::TestCase
-  setup { @list = Kredis.unique_list "myuniquelist" }
+  setup { @list = Kredis.unique_list "myuniquelist", limit: 5 }
 
   test "append" do
     @list.append(%w[ 1 2 3 ])
@@ -50,5 +50,17 @@ class UniqueListTest < ActiveSupport::TestCase
 
     @list.append [ 1, 2 ]
     assert @list.exists?
+  end
+
+  test "appending over limit" do
+    @list.append(%w[ 1 2 3 4 5 ])
+    @list.append(%w[ 6 7 8 ])
+    assert_equal %w[ 4 5 6 7 8 ], @list.elements
+  end
+
+  test "prepending over limit" do
+    @list.prepend(%w[ 1 2 3 4 5 ])
+    @list.prepend(%w[ 6 7 8 ])
+    assert_equal %w[ 8 7 6 5 4 ], @list.elements
   end
 end


### PR DESCRIPTION
When appending to a unique list with a limit, `ltrim` was clearing out the list every time.

> Out of range indexes will not produce an error: if start is larger than the end of the list, or start > end, the result will be an empty list (which causes key to be removed).

This changes it to calculate the limit from the end to preserve the list properly.

@kaspth 