### PR TITLE
Added kredis_boolean class method.

### DIFF
--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -70,6 +70,10 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, typed: typed, config: config, after_change: after_change
     end
 
+    def kredis_boolean(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
+    end
+
     private
       def kredis_connection_with(method, name, key, **options)
         ivar_symbol = :"@#{name}_#{method}"

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -25,6 +25,7 @@ class Person
   kredis_counter :amount
   kredis_string :temporary_password, expires_in: 1.second
   kredis_hash :high_scores, typed: :integer
+  kredis_boolean :onboarded
 
   def self.name
     "Person"
@@ -216,6 +217,14 @@ class AttributesTest < ActiveSupport::TestCase
     assert_equal({ "space_invaders" => 100, "pong" => 42 }, @person.high_scores.to_h)
     assert_equal([ "space_invaders", "pong" ], @person.high_scores.keys)
     assert_equal([ 100, 42 ], @person.high_scores.values)
+  end
+
+  test "boolean" do
+    @person.onboarded.value = true
+    assert @person.onboarded.value
+
+    @person.onboarded.value = false
+    refute @person.onboarded.value
   end
 
   test "missing id to constrain key" do


### PR DESCRIPTION
Couldn't find a way to add a boolean in an active record model. Not sure there is an obvious way to do this, but just in case I added it in this PR.

It is now possible to do this:

```ruby
class Person < Application
  kredis_boolean :onboarded
end
```

