### PR TITLE
Add expires_in support to kredis_counter attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ class Person < ApplicationRecord
   kredis_list :names_with_custom_key, key: ->(p) { "person:#{p.id}:names_customized" }
   kredis_unique_list :skills, limit: 2
   kredis_enum :morning, values: %w[ bright blue black ], default: "bright"
+  kredis_counter :steps, expires_in: 1.hour
 end
 
 person = Person.find(5)

--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -62,8 +62,8 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, available: available, config: config, after_change: after_change
     end
 
-    def kredis_counter(name, key: nil, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, config: config, after_change: after_change
+    def kredis_counter(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
     end
 
     def kredis_hash(name, key: nil, typed: :string, config: :shared, after_change: nil)

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -23,6 +23,7 @@ class Person
   kredis_set :vacations
   kredis_json :settings
   kredis_counter :amount
+  kredis_counter :expiring_amount, expires_in: 1.second
   kredis_string :temporary_password, expires_in: 1.second
   kredis_hash :high_scores, typed: :integer
 
@@ -209,6 +210,13 @@ class AttributesTest < ActiveSupport::TestCase
     assert_equal 1, @person.amount.value
     @person.amount.decrement
     assert_equal 0, @person.amount.value
+  end
+
+  test "counter with expires_at" do
+    @person.expiring_amount.increment
+    assert_changes "@person.expiring_amount.value", from: 1, to: 0 do
+      sleep 1.1.seconds
+    end
   end
 
   test "hash" do


### PR DESCRIPTION
This allows the use of `expires_in` when using the kredis_counter model attribute