### PR TITLE
Provide Hash#clear and List#clear

### DIFF
--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -28,6 +28,7 @@ class Kredis::Types::Hash < Kredis::Types::Proxying
   def remove
     del
   end
+  alias clear remove
 
   def entries
     (hgetall || {}).transform_values { |val| string_to_type(val, typed) }.with_indifferent_access

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -20,4 +20,8 @@ class Kredis::Types::List < Kredis::Types::Proxying
     rpush types_to_strings(elements, typed) if elements.flatten.any?
   end
   alias << append
+
+  def clear
+    del
+  end
 end

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -1,5 +1,5 @@
 class Kredis::Types::List < Kredis::Types::Proxying
-  proxying :lrange, :lrem, :lpush, :rpush, :exists?
+  proxying :lrange, :lrem, :lpush, :rpush, :exists?, :del
 
   attr_accessor :typed
 

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -77,6 +77,13 @@ class HashTest < ActiveSupport::TestCase
     assert_equal({}, @hash.to_h)
   end
 
+  test "clear" do
+    @hash.update("key2" => "value2")
+    assert_equal "value2", @hash["key2"]
+    @hash.clear
+    assert_equal({}, @hash.to_h)
+  end
+
   test "exists?" do
     assert_not @hash.exists?
 

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -35,6 +35,12 @@ class ListTest < ActiveSupport::TestCase
     assert_equal %w[ 4 ], @list.elements
   end
 
+  test "clear" do
+    @list.append(%w[ 1 2 3 4 ])
+    @list.clear
+    assert_equal [], @list.elements
+  end
+
   test "typed as datetime" do
     @list = Kredis.list "mylist", typed: :datetime
 


### PR DESCRIPTION
analog to the stdlib `Enumrable` clear methods `Hash#clear` and `Array#clear`, and in accordance with `Set#clear`