### PR TITLE
Fix after_change callback for unique_list

### DIFF
--- a/lib/kredis/types/callbacks_proxy.rb
+++ b/lib/kredis/types/callbacks_proxy.rb
@@ -11,7 +11,8 @@ class Kredis::Types::CallbacksProxy
     Kredis::Types::List => %i[ remove prepend append << ],
     Kredis::Types::Scalar => %i[ value= clear ],
     Kredis::Types::Set => %i[ add << remove replace take clear ],
-    Kredis::Types::Slots => %i[ reserve release reset ]
+    Kredis::Types::Slots => %i[ reserve release reset ],
+    Kredis::Types::UniqueList => %i[ remove prepend append << ]
   }
 
   def initialize(type, callback)

--- a/test/attributes_callbacks_test.rb
+++ b/test/attributes_callbacks_test.rb
@@ -18,6 +18,11 @@ class AttributesCallbacksTest < ActiveSupport::TestCase
     assert_callback_executed_for :kredis_list, :method, ->(type) { type << %w[ david kasper ] }
   end
 
+  test "unique_list with after_change callback" do
+    assert_callback_executed_for :kredis_unique_list, :proc,   ->(type) { type.append %w[ david kasper ] }
+    assert_callback_executed_for :kredis_unique_list, :method, ->(type) { type << %w[ david kasper ] }
+  end
+
   test "flag with after_change callback" do
     assert_callback_executed_for :kredis_flag, :proc,   ->(type) { type.mark }
     assert_callback_executed_for :kredis_flag, :method, ->(type) { type.mark }

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -72,4 +72,12 @@ class CallbacksTest < ActiveSupport::TestCase
 
     assert_equal 1, @callback_check
   end
+
+  test "unique list with after_change proc callback" do
+    @callback_check = nil
+    names = Kredis.unique_list "names", after_change: ->(list) { @callback_check = list.elements }
+    names.append %w[ david kasper ]
+
+    assert_equal %w[ david kasper ], @callback_check
+  end
 end


### PR DESCRIPTION
Fix: #64 

This fix will support `after_change` callback for `unique_list`

```
class Person < ApplicationRecord
  kredis_list :names, after_change: ->(p) {  }
  kredis_unique_list :skills, limit: 2, after_change: :skillset_changed

  def skillset_changed
    puts 'skillset_changed'
  end
end
```

```
Loading development environment (Rails 7.0.0)
3.0.0 :001 > Person.last.skills << 'rails'
  Person Load (0.2ms)  SELECT "persons".* FROM "persons" ORDER BY "persons"."id" DESC LIMIT ?  [["LIMIT", 1]]
  Kredis Proxy (0.0ms)  LREM persons:2:skills [0, "rails"]
  Kredis Proxy (0.0ms)  RPUSH persons:2:skills ["rails"]
  Kredis Proxy (0.0ms)  LTRIM persons:2:skills [-5, -1]
skillset_changed
 => [0, 2, "OK"]
```