### PR TITLE
Use block parameter to pipeline in Redis#multi

### DIFF
--- a/lib/kredis/types/counter.rb
+++ b/lib/kredis/types/counter.rb
@@ -1,19 +1,19 @@
 class Kredis::Types::Counter < Kredis::Types::Proxying
-  proxying :multi, :set, :get, :del, :exists?
+  proxying :multi, :set, :incrby, :decrby, :get, :del, :exists?
 
   attr_accessor :expires_in
 
   def increment(by: 1)
     multi do |pipeline|
-      pipeline.set key, 0, ex: expires_in, nx: true
-      pipeline.incrby key, by
+      pipeline.set 0, ex: expires_in, nx: true
+      pipeline.incrby by
     end
   end
 
   def decrement(by: 1)
     multi do |pipeline|
-      pipeline.set key, 0, ex: expires_in, nx: true
-      pipeline.decrby key, by
+      pipeline.set 0, ex: expires_in, nx: true
+      pipeline.decrby by
     end
   end
 

--- a/lib/kredis/types/counter.rb
+++ b/lib/kredis/types/counter.rb
@@ -1,19 +1,19 @@
 class Kredis::Types::Counter < Kredis::Types::Proxying
-  proxying :multi, :set, :incrby, :decrby, :get, :del, :exists?
+  proxying :multi, :set, :get, :del, :exists?
 
   attr_accessor :expires_in
 
   def increment(by: 1)
     multi do |pipeline|
-      pipeline.set 0, ex: expires_in, nx: true
-      pipeline.incrby by
+      pipeline.set key, 0, ex: expires_in, nx: true
+      pipeline.incrby key, by
     end
   end
 
   def decrement(by: 1)
     multi do |pipeline|
-      pipeline.set 0, ex: expires_in, nx: true
-      pipeline.decrby by
+      pipeline.set key, 0, ex: expires_in, nx: true
+      pipeline.decrby key, by
     end
   end
 

--- a/lib/kredis/types/counter.rb
+++ b/lib/kredis/types/counter.rb
@@ -4,16 +4,16 @@ class Kredis::Types::Counter < Kredis::Types::Proxying
   attr_accessor :expires_in
 
   def increment(by: 1)
-    multi do
-      set 0, ex: expires_in, nx: true
-      incrby by
+    multi do |pipeline|
+      pipeline.set 0, ex: expires_in, nx: true
+      pipeline.incrby by
     end
   end
 
   def decrement(by: 1)
-    multi do
-      set 0, ex: expires_in, nx: true
-      decrby by
+    multi do |pipeline|
+      pipeline.set 0, ex: expires_in, nx: true
+      pipeline.decrby by
     end
   end
 

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -8,16 +8,16 @@ class Kredis::Types::List < Kredis::Types::Proxying
   end
   alias to_a elements
 
-  def remove(*elements)
-    types_to_strings(elements, typed).each { |element| lrem 0, element }
+  def remove(*elements, pipeline: nil)
+    types_to_strings(elements, typed).each { |element| (pipeline || proxy).lrem 0, element }
   end
 
-  def prepend(*elements)
-    lpush types_to_strings(elements, typed) if elements.flatten.any?
+  def prepend(*elements, pipeline: nil)
+    (pipeline || proxy).lpush types_to_strings(elements, typed) if elements.flatten.any?
   end
 
-  def append(*elements)
-    rpush types_to_strings(elements, typed) if elements.flatten.any?
+  def append(*elements, pipeline: nil)
+    (pipeline || proxy).rpush types_to_strings(elements, typed) if elements.flatten.any?
   end
   alias << append
 end

--- a/lib/kredis/types/proxy.rb
+++ b/lib/kredis/types/proxy.rb
@@ -9,8 +9,13 @@ class Kredis::Types::Proxy
     options.each { |key, value| send("#{key}=", value) }
   end
 
-  def multi(...)
-    redis.multi(...)
+  def multi(&block)
+    # NOTE: to be removed when Redis 4 compatibility gets dropped
+    return redis.multi unless block
+
+    redis.multi do |pipeline|
+      block.call(Kredis::Types::Proxy.new(pipeline, key))
+    end
   end
 
   def method_missing(method, *args, **kwargs)

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -19,8 +19,8 @@ class Kredis::Types::Set < Kredis::Types::Proxying
 
   def replace(*members)
     multi do |pipeline|
-      pipeline.del
-      pipeline.add members
+      pipeline.del key
+      pipeline.sadd key, types_to_strings(members, typed) if members.flatten.any?
     end
   end
 

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -18,9 +18,9 @@ class Kredis::Types::Set < Kredis::Types::Proxying
   end
 
   def replace(*members)
-    multi do
-      del
-      add members
+    multi do |pipeline|
+      pipeline.del
+      pipeline.add members
     end
   end
 

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -8,19 +8,19 @@ class Kredis::Types::Set < Kredis::Types::Proxying
   end
   alias to_a members
 
-  def add(*members)
-    sadd types_to_strings(members, typed) if members.flatten.any?
+  def add(*members, pipeline: nil)
+    (pipeline || proxy).sadd types_to_strings(members, typed) if members.flatten.any?
   end
   alias << add
 
-  def remove(*members)
-    srem types_to_strings(members, typed) if members.flatten.any?
+  def remove(*members, pipeline: nil)
+    (pipeline || proxy).srem types_to_strings(members, typed) if members.flatten.any?
   end
 
   def replace(*members)
     multi do |pipeline|
-      pipeline.del key
-      pipeline.sadd key, types_to_strings(members, typed) if members.flatten.any?
+      pipeline.del
+      add members, pipeline: pipeline
     end
   end
 

--- a/lib/kredis/types/unique_list.rb
+++ b/lib/kredis/types/unique_list.rb
@@ -8,10 +8,10 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     elements = Array(elements).uniq
     return if elements.empty?
 
-    multi do
-      remove elements
+    multi do |pipeline|
+      pipeline.remove elements
       super
-      ltrim 0, (limit - 1) if limit
+      pipeline.ltrim 0, (limit - 1) if limit
     end
   end
 
@@ -19,10 +19,10 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     elements = Array(elements).uniq
     return if elements.empty?
 
-    multi do
-      remove elements
+    multi do |pipeline|
+      pipeline.remove elements
       super
-      ltrim -limit, -1 if limit
+      pipeline.ltrim -limit, -1 if limit
     end
   end
   alias << append

--- a/lib/kredis/types/unique_list.rb
+++ b/lib/kredis/types/unique_list.rb
@@ -1,6 +1,6 @@
 # You'd normally call this a set, but Redis already has another data type for that
 class Kredis::Types::UniqueList < Kredis::Types::List
-  proxying :multi, :ltrim, :exists?
+  proxying :multi, :exists?
 
   attr_accessor :typed, :limit
 
@@ -9,9 +9,9 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     return if elements.empty?
 
     multi do |pipeline|
-      pipeline.remove elements
+      types_to_strings(elements, typed).each { |element| pipeline.lrem key, 0, element }
       super
-      pipeline.ltrim 0, (limit - 1) if limit
+      pipeline.ltrim key, 0, (limit - 1) if limit
     end
   end
 
@@ -20,9 +20,9 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     return if elements.empty?
 
     multi do |pipeline|
-      pipeline.remove elements
+      types_to_strings(elements, typed).each { |element| pipeline.lrem key, 0, element }
       super
-      pipeline.ltrim -limit, -1 if limit
+      pipeline.ltrim key, -limit, -1 if limit
     end
   end
   alias << append

--- a/lib/kredis/types/unique_list.rb
+++ b/lib/kredis/types/unique_list.rb
@@ -1,6 +1,6 @@
 # You'd normally call this a set, but Redis already has another data type for that
 class Kredis::Types::UniqueList < Kredis::Types::List
-  proxying :multi, :exists?
+  proxying :multi, :ltrim, :exists?
 
   attr_accessor :typed, :limit
 
@@ -9,9 +9,9 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     return if elements.empty?
 
     multi do |pipeline|
-      types_to_strings(elements, typed).each { |element| pipeline.lrem key, 0, element }
+      remove elements, pipeline: pipeline
       super
-      pipeline.ltrim key, 0, (limit - 1) if limit
+      pipeline.ltrim 0, (limit - 1) if limit
     end
   end
 
@@ -20,9 +20,9 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     return if elements.empty?
 
     multi do |pipeline|
-      types_to_strings(elements, typed).each { |element| pipeline.lrem key, 0, element }
+      remove elements, pipeline: pipeline
       super
-      pipeline.ltrim key, -limit, -1 if limit
+      pipeline.ltrim -limit, -1 if limit
     end
   end
   alias << append


### PR DESCRIPTION
In preparation of Redis 5, as info message alerts.

> Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.
>
> redis.multi do
>   redis.get("key")
> end
>
> should be replaced by
>
> redis.multi do |pipeline|
>   pipeline.get("key")
> end
>
> (called from /app/vendor/bundle/ruby/2.7.0/gems/kredis-1.0.1/lib/kredis/types/proxy.rb:13:in `multi'}>

Using block parameter is compatible down to [`redis` gem version 3.0](https://www.rubydoc.info/gems/redis/3.0.0/Redis#multi-instance_method), current dependency to `redis` is defined as `~> 4.2`.

