### PR TITLE
Avoid having to pass a Redis pipeline argument around

### DIFF
--- a/lib/kredis.rb
+++ b/lib/kredis.rb
@@ -1,5 +1,6 @@
 require "active_support"
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/module/attribute_accessors_per_thread"
 
 require "kredis/version"
 

--- a/lib/kredis/migration.rb
+++ b/lib/kredis/migration.rb
@@ -5,7 +5,6 @@ class Kredis::Migration
 
   def initialize(config = :shared)
     @redis = Kredis.configured_for config
-    @pipeline = nil
     # TODO: Replace script loading with `copy` command once Redis 6.2+ is the minimum supported version.
     @copy_sha = @redis.script "load", "redis.call('SETNX', KEYS[2], redis.call('GET', KEYS[1])); return 1;"
   end
@@ -39,10 +38,6 @@ class Kredis::Migration
 
   private
     SCAN_BATCH_SIZE = 1_000
-
-    def connection
-      @pipeline || @redis
-    end
 
     def each_key_batch_matching(key_pattern, &block)
       cursor = "0"

--- a/lib/kredis/types/counter.rb
+++ b/lib/kredis/types/counter.rb
@@ -4,16 +4,16 @@ class Kredis::Types::Counter < Kredis::Types::Proxying
   attr_accessor :expires_in
 
   def increment(by: 1)
-    multi do |pipeline|
-      pipeline.set 0, ex: expires_in, nx: true
-      pipeline.incrby by
+    multi do
+      set 0, ex: expires_in, nx: true
+      incrby by
     end[-1]
   end
 
   def decrement(by: 1)
-    multi do |pipeline|
-      pipeline.set 0, ex: expires_in, nx: true
-      pipeline.decrby by
+    multi do
+      set 0, ex: expires_in, nx: true
+      decrby by
     end[-1]
   end
 

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -8,16 +8,16 @@ class Kredis::Types::List < Kredis::Types::Proxying
   end
   alias to_a elements
 
-  def remove(*elements, pipeline: nil)
-    types_to_strings(elements, typed).each { |element| (pipeline || proxy).lrem 0, element }
+  def remove(*elements)
+    types_to_strings(elements, typed).each { |element| lrem 0, element }
   end
 
-  def prepend(*elements, pipeline: nil)
-    (pipeline || proxy).lpush types_to_strings(elements, typed) if elements.flatten.any?
+  def prepend(*elements)
+    lpush types_to_strings(elements, typed) if elements.flatten.any?
   end
 
-  def append(*elements, pipeline: nil)
-    (pipeline || proxy).rpush types_to_strings(elements, typed) if elements.flatten.any?
+  def append(*elements)
+    rpush types_to_strings(elements, typed) if elements.flatten.any?
   end
   alias << append
 

--- a/lib/kredis/types/proxy.rb
+++ b/lib/kredis/types/proxy.rb
@@ -2,7 +2,7 @@ class Kredis::Types::Proxy
   require_relative "proxy/failsafe"
   include Failsafe
 
-  attr_accessor :redis, :key
+  attr_accessor :key
 
   thread_mattr_accessor :pipeline
 
@@ -23,12 +23,16 @@ class Kredis::Types::Proxy
   def method_missing(method, *args, **kwargs)
     Kredis.instrument :proxy, **log_message(method, *args, **kwargs) do
       failsafe do
-        (pipeline || redis).public_send method, key, *args, **kwargs
+        redis.public_send method, key, *args, **kwargs
       end
     end
   end
 
   private
+    def redis
+      pipeline || @redis
+    end
+
     def log_message(method, *args, **kwargs)
       args      = args.flatten.reject(&:blank?).presence
       kwargs    = kwargs.reject { |_k, v| v.blank? }.presence

--- a/lib/kredis/types/proxying.rb
+++ b/lib/kredis/types/proxying.rb
@@ -1,14 +1,14 @@
 require "active_support/core_ext/module/delegation"
 
 class Kredis::Types::Proxying
-  attr_accessor :proxy, :redis, :key
+  attr_accessor :proxy, :key
 
   def self.proxying(*commands)
     delegate *commands, to: :proxy
   end
 
   def initialize(redis, key, **options)
-    @redis, @key = redis, key
+    @key = key
     @proxy = Kredis::Types::Proxy.new(redis, key)
     options.each { |key, value| send("#{key}=", value) }
   end

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -8,19 +8,19 @@ class Kredis::Types::Set < Kredis::Types::Proxying
   end
   alias to_a members
 
-  def add(*members, pipeline: nil)
-    (pipeline || proxy).sadd types_to_strings(members, typed) if members.flatten.any?
+  def add(*members)
+    sadd types_to_strings(members, typed) if members.flatten.any?
   end
   alias << add
 
-  def remove(*members, pipeline: nil)
-    (pipeline || proxy).srem types_to_strings(members, typed) if members.flatten.any?
+  def remove(*members)
+    srem types_to_strings(members, typed) if members.flatten.any?
   end
 
   def replace(*members)
-    multi do |pipeline|
-      pipeline.del
-      add members, pipeline: pipeline
+    multi do
+      del
+      add members
     end
   end
 

--- a/lib/kredis/types/unique_list.rb
+++ b/lib/kredis/types/unique_list.rb
@@ -8,10 +8,10 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     elements = Array(elements).uniq
     return if elements.empty?
 
-    multi do |pipeline|
-      remove elements, pipeline: pipeline
-      super(elements, pipeline: pipeline)
-      pipeline.ltrim 0, (limit - 1) if limit
+    multi do
+      remove elements
+      super
+      ltrim 0, (limit - 1) if limit
     end
   end
 
@@ -19,10 +19,10 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     elements = Array(elements).uniq
     return if elements.empty?
 
-    multi do |pipeline|
-      remove elements, pipeline: pipeline
-      super(elements, pipeline: pipeline)
-      pipeline.ltrim -limit, -1 if limit
+    multi do
+      remove elements
+      super
+      ltrim -limit, -1 if limit
     end
   end
   alias << append


### PR DESCRIPTION
Improves upon https://github.com/rails/kredis/pulls/68 by simplifying the internal implementation, avoiding passing a pipeline as a method argument