### PR TITLE
Add reset to Cycle after_change callbacks

### DIFF
--- a/lib/kredis/types/callbacks_proxy.rb
+++ b/lib/kredis/types/callbacks_proxy.rb
@@ -4,7 +4,7 @@ class Kredis::Types::CallbacksProxy
 
   AFTER_CHANGE_OPERATIONS = {
     Kredis::Types::Counter => %i[ increment decrement reset ],
-    Kredis::Types::Cycle => %i[ next ],
+    Kredis::Types::Cycle => %i[ next reset ],
     Kredis::Types::Enum => %i[ value= reset ],
     Kredis::Types::Flag => %i[ mark remove ],
     Kredis::Types::Hash => %i[ update delete []= remove ],

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -73,6 +73,17 @@ class CallbacksTest < ActiveSupport::TestCase
     assert_equal 1, @callback_check
   end
 
+  test "cycle with after_change proc callback" do
+    @callback_check = nil
+    amount = Kredis.cycle "semaphore_light", after_change: ->(cycle) { @callback_check = cycle.value }, values: %w[ green yellow red ]
+
+    amount.next
+    assert_equal "yellow", @callback_check
+
+    amount.reset
+    assert_equal "green", @callback_check
+  end
+
   test "unique list with after_change proc callback" do
     @callback_check = nil
     names = Kredis.unique_list "names", after_change: ->(list) { @callback_check = list.elements }


### PR DESCRIPTION
`reset` is a public action exposed by `Cycle` and should be included in the `after_change` callbacks lifecycle.