### PR TITLE
Support configuring custom keys via method invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,16 @@ You can use all these structures in models:
 ```ruby
 class Person < ApplicationRecord
   kredis_list :names
-  kredis_list :names_with_custom_key, key: ->(p) { "person:#{p.id}:names_customized" }
+  kredis_list :names_with_custom_key_via_lambda, key: ->(p) { "person:#{p.id}:names_customized" }
+  kredis_list :names_with_custom_key_via_method, key: :generate_names_key
   kredis_unique_list :skills, limit: 2
   kredis_enum :morning, values: %w[ bright blue black ], default: "bright"
   kredis_counter :steps, expires_in: 1.hour
+
+  private
+    def generate_names_key
+      "key-generated-from-private-method"
+    end
 end
 
 person = Person.find(5)

--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -97,6 +97,7 @@ module Kredis::Attributes
       case key
       when String then key
       when Proc   then key.call(self)
+      when Symbol then send(key)
       end
     end
 


### PR DESCRIPTION
This adds support to generate keys via a method name passed as a symbol:

```ruby
class Person
  kredis_list :names, key: :generate_key

  private
    def generate_key
      "some generated key"
    end
end
```

Currently, the only way to customize keys is via a lambda, lilke `key: ->(p) { "person:#{p.id}:names_customized" }`. The problem with that approach is that, when you want to invoke a method to determine the key, you need to make that method public. This is also a more concise way of covering a pretty common use case: using an instance method to determine keys.


