### PR TITLE
Support expires_in timeout for Lists / UniqueLists

### DIFF
--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -42,8 +42,8 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_list(name, key: nil, typed: :string, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, typed: typed, config: config, after_change: after_change
+    def kredis_list(name, key: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, typed: typed, config: config, after_change: after_change, expires_in: expires_in
     end
 
     def kredis_unique_list(name, limit: nil, key: nil, typed: :string, config: :shared, after_change: nil)

--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -46,8 +46,8 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, typed: typed, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_unique_list(name, limit: nil, key: nil, typed: :string, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, limit: limit, typed: typed, config: config, after_change: after_change
+    def kredis_unique_list(name, limit: nil, key: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, limit: limit, typed: typed, config: config, after_change: after_change, expires_in: expires_in
     end
 
     def kredis_set(name, key: nil, typed: :string, config: :shared, after_change: nil)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -59,8 +59,8 @@ module Kredis::Types
     type_from(Hash, config, key, after_change: after_change, typed: typed)
   end
 
-  def list(key, typed: :string, config: :shared, after_change: nil)
-    type_from(List, config, key, after_change: after_change, typed: typed)
+  def list(key, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+    type_from(List, config, key, after_change: after_change, typed: typed, expires_in: expires_in)
   end
 
   def unique_list(key, typed: :string, limit: nil, config: :shared, after_change: nil)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -63,8 +63,8 @@ module Kredis::Types
     type_from(List, config, key, after_change: after_change, typed: typed, expires_in: expires_in)
   end
 
-  def unique_list(key, typed: :string, limit: nil, config: :shared, after_change: nil)
-    type_from(UniqueList, config, key, after_change: after_change, typed: typed, limit: limit)
+  def unique_list(key, typed: :string, limit: nil, config: :shared, after_change: nil,  expires_in: nil)
+    type_from(UniqueList, config, key, after_change: after_change, typed: typed, limit: limit, expires_in: expires_in)
   end
 
   def set(key, typed: :string, config: :shared, after_change: nil)

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -10,21 +10,26 @@ class Kredis::Types::List < Kredis::Types::Proxying
 
   def remove(*elements, pipeline: nil)
     types_to_strings(elements, typed).each { |element| (pipeline || proxy).lrem 0, element }
-    (pipeline || proxy).expire expires_in.to_i if expires_in
+    refresh_expiration(pipeline || proxy)
   end
 
   def prepend(*elements, pipeline: nil)
     (pipeline || proxy).lpush types_to_strings(elements, typed) if elements.flatten.any?
-    (pipeline || proxy).expire expires_in.to_i if expires_in
+    refresh_expiration(pipeline || proxy)
   end
 
   def append(*elements, pipeline: nil)
     (pipeline || proxy).rpush types_to_strings(elements, typed) if elements.flatten.any?
-    (pipeline || proxy).expire expires_in.to_i if expires_in
+    refresh_expiration(pipeline || proxy)
   end
   alias << append
 
   def clear
     del
   end
+
+  private
+    def refresh_expiration(target)
+      target.expire expires_in.to_i if expires_in
+    end
 end

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -10,17 +10,17 @@ class Kredis::Types::List < Kredis::Types::Proxying
 
   def remove(*elements, pipeline: nil)
     types_to_strings(elements, typed).each { |element| (pipeline || proxy).lrem 0, element }
-    expire expires_in.to_i if expires_in
+    (pipeline || proxy).expire expires_in.to_i if expires_in
   end
 
   def prepend(*elements, pipeline: nil)
     (pipeline || proxy).lpush types_to_strings(elements, typed) if elements.flatten.any?
-    expire expires_in.to_i if expires_in
+    (pipeline || proxy).expire expires_in.to_i if expires_in
   end
 
   def append(*elements, pipeline: nil)
     (pipeline || proxy).rpush types_to_strings(elements, typed) if elements.flatten.any?
-    expire expires_in.to_i if expires_in
+    (pipeline || proxy).expire expires_in.to_i if expires_in
   end
   alias << append
 

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -1,7 +1,7 @@
 class Kredis::Types::List < Kredis::Types::Proxying
-  proxying :lrange, :lrem, :lpush, :rpush, :exists?, :del
+  proxying :lrange, :lrem, :lpush, :rpush, :exists?, :del, :expire
 
-  attr_accessor :typed
+  attr_accessor :typed, :expires_in
 
   def elements
     strings_to_types(lrange(0, -1) || [], typed)
@@ -10,14 +10,17 @@ class Kredis::Types::List < Kredis::Types::Proxying
 
   def remove(*elements, pipeline: nil)
     types_to_strings(elements, typed).each { |element| (pipeline || proxy).lrem 0, element }
+    expire expires_in.to_i if expires_in
   end
 
   def prepend(*elements, pipeline: nil)
     (pipeline || proxy).lpush types_to_strings(elements, typed) if elements.flatten.any?
+    expire expires_in.to_i if expires_in
   end
 
   def append(*elements, pipeline: nil)
     (pipeline || proxy).rpush types_to_strings(elements, typed) if elements.flatten.any?
+    expire expires_in.to_i if expires_in
   end
   alias << append
 

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -1,5 +1,5 @@
 class Kredis::Types::List < Kredis::Types::Proxying
-  proxying :lrange, :lrem, :lpush, :rpush, :exists?, :del, :expire
+  proxying :lrange, :lrem, :lpush, :rpush, :exists?, :del, :expire, :ttl
 
   attr_accessor :typed, :expires_in
 

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -12,6 +12,7 @@ class Person
   kredis_list :names_with_custom_key_via_method, key: :generate_key
   kredis_list :expiring_list, expires_in: 1.second
   kredis_unique_list :skills, limit: 2
+  kredis_unique_list :expiring_skills, expires_in: 1.second
   kredis_flag :special
   kredis_flag :temporary_special, expires_in: 1.second
   kredis_string :address
@@ -99,6 +100,14 @@ class AttributesTest < ActiveSupport::TestCase
     @person.skills.prepend("racing")
     @person.skills.prepend("racing")
     assert_equal %w[ racing photography ], @person.skills.elements
+  end
+
+  test "expiring unique list" do
+    @person.expiring_skills.prepend("racing")
+    @person.expiring_skills.prepend("racing")
+    assert_changes "@person.expiring_skills.elements", from: %w[ racing ], to: %w[] do
+      sleep 1.1.seconds
+    end
   end
 
   test "flag" do

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -41,7 +41,7 @@ class ListTest < ActiveSupport::TestCase
     assert_equal [], @list.elements
   end
 
-  test "expiring lists" do
+  test "expiring" do
     @list = Kredis.list "mylist", expires_in: 1.second
     @list.append(%w[ 1 2 3 ])
 

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -41,6 +41,26 @@ class ListTest < ActiveSupport::TestCase
     assert_equal [], @list.elements
   end
 
+  test "expiring lists" do
+    @list = Kredis.list "mylist", expires_in: 1.second
+    @list.append(%w[ 1 2 3 ])
+
+    assert_equal %w[ 1 2 3 ], @list.elements
+
+    sleep 1.1.seconds
+
+    assert_equal [], @list.elements
+
+    @list.prepend(4)
+
+    sleep 0.6.seconds
+
+    assert_equal %w[ 4 ], @list.elements
+
+    sleep 0.5.seconds
+    assert_equal [], @list.elements
+  end
+
   test "typed as datetime" do
     @list = Kredis.list "mylist", typed: :datetime
 

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -41,24 +41,28 @@ class ListTest < ActiveSupport::TestCase
     assert_equal [], @list.elements
   end
 
-  test "expiring" do
-    @list = Kredis.list "mylist", expires_in: 1.second
+  test "expires_in option" do
+    @list = Kredis.list "mylist", expires_in: 30.second
     @list.append(%w[ 1 2 3 ])
-
+    assert_equal @list.expires_in, @list.ttl
     assert_equal %w[ 1 2 3 ], @list.elements
 
-    sleep 1.1.seconds
-
+    @list.expire 0
+    assert_equal -2, @list.ttl
     assert_equal [], @list.elements
 
     @list.prepend(4)
-
-    sleep 0.6.seconds
-
+    assert_equal @list.expires_in, @list.ttl
     assert_equal %w[ 4 ], @list.elements
 
-    sleep 0.5.seconds
+    @list.expire 0
+    assert_equal -2, @list.ttl
     assert_equal [], @list.elements
+
+    @list.append(%w[ 1 2 3 ])
+    @list.remove(%w[ 1 2 ])
+    assert_equal @list.expires_in, @list.ttl
+    assert_equal %w[ 3 ], @list.elements
   end
 
   test "typed as datetime" do

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "active_support/core_ext/integer"
 
 class UniqueListTest < ActiveSupport::TestCase
   setup { @list = Kredis.unique_list "myuniquelist", limit: 5 }
@@ -72,5 +73,25 @@ class UniqueListTest < ActiveSupport::TestCase
   test "prepending array with duplicates" do
     @list.prepend(%w[ 1 1 1 ])
     assert_equal %w[ 1 ], @list.elements
+  end
+
+  test "expiring lists" do
+    @list = Kredis.unique_list "myuniquelist", expires_in: 1.second
+    @list.append(%w[ 1 2 3 ])
+
+    assert_equal %w[ 1 2 3 ], @list.elements
+
+    sleep 1.1.seconds
+
+    assert_equal [], @list.elements
+
+    @list.prepend(4)
+
+    sleep 0.6.seconds
+
+    assert_equal %w[ 4 ], @list.elements
+
+    sleep 0.5.seconds
+    assert_equal [], @list.elements
   end
 end

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -75,7 +75,7 @@ class UniqueListTest < ActiveSupport::TestCase
     assert_equal %w[ 1 ], @list.elements
   end
 
-  test "expiring lists" do
+  test "expiring" do
     @list = Kredis.unique_list "myuniquelist", expires_in: 1.second
     @list.append(%w[ 1 2 3 ])
 

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -75,23 +75,18 @@ class UniqueListTest < ActiveSupport::TestCase
     assert_equal %w[ 1 ], @list.elements
   end
 
-  test "expiring" do
-    @list = Kredis.unique_list "myuniquelist", expires_in: 1.second
+  test "expires_in option" do
+    @list = Kredis.unique_list "myuniquelist", expires_in: 15.second
     @list.append(%w[ 1 2 3 ])
-
+    assert_equal @list.expires_in, @list.ttl
     assert_equal %w[ 1 2 3 ], @list.elements
 
-    sleep 1.1.seconds
-
+    @list.expire 0
+    assert_equal -2, @list.ttl
     assert_equal [], @list.elements
 
     @list.prepend(4)
-
-    sleep 0.6.seconds
-
+    assert_equal @list.expires_in, @list.ttl
     assert_equal %w[ 4 ], @list.elements
-
-    sleep 0.5.seconds
-    assert_equal [], @list.elements
   end
 end


### PR DESCRIPTION
Similar to https://github.com/rails/kredis/pull/19

Adds support for expiring lists (and unique lists).

You specify a "timeout" via `expires_in` when defining the attribute. Adding or removing items from the list bumps the timeout. This is due to how Redis works internally -- calling `lpush` or `rpush` on a key will clear any existing expiry, so after the list has been modified, we have to resend the `expire` command.

## Motivation

We have a use-case for Kredis where we want to store a list of IDs for items that a user can collapse/expand. But after a few hours/days, we don't need to keep persisting the state. This prevents our Redis storage space from expanding indefinitely as old lists will eventually expire.

```rb
class Users::PlanState
  include Kredis::Attributes
  
  kredis_list :expanded_item_ids, expires_in: 3.days

  attr_accessor :user, :plan

  def id
    "users:#{user.id}:plans:#{plan.id}"
  end

  def item_expanded?(item)
    expanded_item_ids.include?(item.id)
  end
end
```

Without this change, we have to workaround the inability to expire lists by using the `kredis_json` type to store an array.

A similar example: using Kredis to store user-specified filters. You may want to persist these filters across page visits/reloads but after some time has elapsed, it would be acceptable to "forget" the selection.

![image](https://user-images.githubusercontent.com/56947/172173805-c7e69fb2-61d8-4c87-90fb-0ffa58ba4307.png)
