### PR TITLE
Implement a key search interface through Kredis.search

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,24 @@ class Person < ApplicationRecord
 end
 ```
 
+There is an easy way to search for keys:
+
+```ruby
+# Returns the search results in batches of *approximately* 1.000 keys
+Kredis.search('user_names:*') do |key_batch|
+  key_batch == [ 'user_names:1', 'user_names:2', ... ]
+end
+
+# Optionally you can change the batch size hint. Since it's a hint,
+# there is no guarantee the size of each batch matches the hint.
+#
+# Returns the search results in batches of *approximately* 750 keys 
+Kredis.search('user_names:*', batch_size: 750) { ... }
+
+# Using a different than the default `shared` redis instance, relying on `config/redis/secondary.yml`:
+Kredis.search('user_names:*', config: :secondary) { ... }
+```
+
 ## Installation
 
 1. Run `./bin/bundle add kredis`

--- a/lib/kredis.rb
+++ b/lib/kredis.rb
@@ -6,6 +6,7 @@ require "kredis/version"
 require "kredis/connections"
 require "kredis/log_subscriber"
 require "kredis/namespace"
+require "kredis/queries"
 require "kredis/type_casting"
 require "kredis/types"
 require "kredis/attributes"
@@ -13,7 +14,7 @@ require "kredis/attributes"
 require "kredis/railtie" if defined?(Rails::Railtie)
 
 module Kredis
-  include Connections, Namespace, TypeCasting, Types
+  include Connections, Namespace, Queries, TypeCasting, Types
   extend self
 
   autoload :Migration, "kredis/migration"

--- a/lib/kredis/queries.rb
+++ b/lib/kredis/queries.rb
@@ -1,0 +1,10 @@
+module Kredis::Queries
+  def search(key_pattern, batch_size: 1000, config: :shared, &block)
+    pattern = namespace ? "#{namespace}:#{key_pattern}" : key_pattern
+    cursor = "0"
+    begin
+      cursor, keys = redis(config: config).scan(cursor, match: pattern, count: batch_size)
+      redis.multi { |pipeline| yield keys, pipeline }
+    end until cursor == "0"
+  end
+end

--- a/test/queries_test.rb
+++ b/test/queries_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class QueriesTest < ActiveSupport::TestCase
+  teardown do
+    Kredis.namespace = nil
+  end
+
+  test "search keys" do
+    insert_keys
+
+    should_find_keys = 5.times.map{|i| "mykey:#{i}"}
+    found_keys = []
+    
+    Kredis.search('mykey:*'){ |keys| found_keys += keys }
+    
+    assert_equal should_find_keys.sort, found_keys.sort
+  end
+
+  test "search keys with different batch size" do   
+    insert_keys
+
+    keys_count = 0
+    
+    Kredis.search('mykey:*', batch_size: 3){ |keys| keys_count += keys.size }
+
+    assert_equal 5, keys_count    
+  end
+
+  test "search keys with namespace" do
+    insert_keys('mynamespace')
+
+    should_find_keys = 5.times.map{|i| "mynamespace:mykey:#{i}"}
+    found_keys = []
+    
+    Kredis.search('mykey:*'){ |keys| found_keys += keys }
+    
+    assert_equal should_find_keys.sort, found_keys.sort
+  end
+
+  test "search keys with different config" do
+    # Config cannot be tested in this test suite so 
+    # for now checking if using the keyword argument passes
+    Kredis.search('mykey:*', config: :secondary) { }
+  end
+
+  private
+
+  def insert_keys(namespace = nil)
+    Kredis.namespace = namespace
+
+    5.times { |i| Kredis.string("mykey:#{i}").value = "1" }
+  end
+
+end


### PR DESCRIPTION
At this moment there is no functionality in Kredis to search for keys. I would like to propose to implement a key search functionality. The functionality abstracts the Redis SCAN command away from the user. 

## Kredis.search
The search function is implemented in `Kredis.search`. It respects `Kredis.namespace` if set.

### Normal usage
Suppose we cache user names via Kredis using `User.first(500).each {|user| Kredis.string("user_names:#{user.id}").value = user.name }`. We want to fetch all user names using Kredis.
```ruby
user_names = []
Kredis.search('user_names:*') do |key_batch| # key_batch.size is approx. 1000 keys
  user_names += key_batch.map { |key| Kredis.string(key).value }
end

(pry)> user_names
=> ["john", "marie", "alice", "bob", ...]
```

### Different batch size
```ruby
...
Kredis.search('user_names:*', batch_size: 200) do |key_batch| # key_batch.size is approx. 200 keys
...
```

### Different config
```ruby
...
Kredis.search('user_names:*', config: :secondary) { ... } # use config/redis/secondary.yml
...
```

## Business case

- It's an easy to use interface
- Users don't have to fall back to raw Redis to scan for keys

### Todo
- The interface still feels a little unruby, especially the disability to map the keys directly into an array feels clunky. Maybe the abstraction should be taken to a higher level? 

Any feedback is very much appreciated! My main doubt: is this something Kredis should take care of? Does it adhere to the spirit of Kredis being a 'keyed' Redis or should users just use raw Redis?
