### PR TITLE
Delete list of keys in batch

### DIFF
--- a/lib/kredis/migration.rb
+++ b/lib/kredis/migration.rb
@@ -31,8 +31,14 @@ class Kredis::Migration
   end
 
   def delete_all(key_pattern)
-    each_key_batch_matching(key_pattern) do |keys, pipeline|
-      pipeline.del *keys
+    log_migration "DELETE ALL #{key_pattern.inspect}" do
+      if key_pattern.is_a? Array
+        @redis.del *key_pattern
+      else
+        each_key_batch_matching(key_pattern) do |keys, pipeline|
+          pipeline.del *keys
+        end
+      end
     end
   end
 

--- a/lib/kredis/migration.rb
+++ b/lib/kredis/migration.rb
@@ -9,8 +9,8 @@ class Kredis::Migration
     @copy_sha = @redis.script "load", "redis.call('SETNX', KEYS[2], redis.call('GET', KEYS[1])); return 1;"
   end
 
-  def migrate_all(key_patterns)
-    each_key_batch_matching(key_patterns) do |keys, pipeline|
+  def migrate_all(key_pattern)
+    each_key_batch_matching(key_pattern) do |keys, pipeline|
       keys.each do |key|
         ids = key.scan(/\d+/).map(&:to_i)
         migrate from: key, to: yield(key, *ids), pipeline: pipeline
@@ -45,10 +45,10 @@ class Kredis::Migration
   private
     SCAN_BATCH_SIZE = 1_000
 
-    def each_key_batch_matching(key_patterns, &block)
+    def each_key_batch_matching(key_pattern, &block)
       cursor = "0"
       begin
-        cursor, keys = @redis.scan(cursor, match: key_patterns, count: SCAN_BATCH_SIZE)
+        cursor, keys = @redis.scan(cursor, match: key_pattern, count: SCAN_BATCH_SIZE)
         @redis.multi { |pipeline| yield keys, pipeline }
       end until cursor == "0"
     end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -51,10 +51,18 @@ class MigrationTest < ActiveSupport::TestCase
     end
   end
 
-  test "delete_all" do
+  test "delete_all with pattern" do
     3.times { |index| Kredis.proxy("mykey:#{index}").set "hello there #{index}" }
 
     Kredis::Migration.delete_all "mykey:*"
+
+    3.times { |index| assert_nil Kredis.proxy("mykey:#{index}").get }
+  end
+
+  test "delete_all with keys" do
+    3.times { |index| Kredis.proxy("mykey:#{index}").set "hello there #{index}" }
+
+    Kredis::Migration.delete_all 3.times.map { |index| "mykey:#{index}" }
 
     3.times { |index| assert_nil Kredis.proxy("mykey:#{index}").get }
   end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -62,7 +62,7 @@ class MigrationTest < ActiveSupport::TestCase
   test "delete_all with keys" do
     3.times { |index| Kredis.proxy("mykey:#{index}").set "hello there #{index}" }
 
-    Kredis::Migration.delete_all 3.times.map { |index| "mykey:#{index}" }
+    Kredis::Migration.delete_all *3.times.map { |index| "mykey:#{index}" }
 
     3.times { |index| assert_nil Kredis.proxy("mykey:#{index}").get }
   end


### PR DESCRIPTION
## SUMMARY

This PR updates the existing `Kredis::Migration#delete_all` method to:
- Allow a key pattern OR array passed to delete keys
- Add logging for `#delete_all`


## DETAILS

There's occasion where you might want to clear a large number of keys, but using a pattern creates too broad of a stroke.

Today, you would have to run:

```ruby
found_users.each { |user| user.my_kredis_key.clear }
```

A much more efficient method would be to delete a list of keys in batch rather than separately:

```ruby
Kredis.redis.del *found_users.map { |user| user.my_kredis_key.key }
```

This change add DSL to the process and logging of the event:

```ruby
Kredis::Migration.delete_all *found_users.map { |user| user.my_kredis_key.key }
```

