### PR TITLE
Extend expirable capability for any type

### DIFF
--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -90,6 +90,7 @@ end
 require "kredis/types/proxy"
 require "kredis/types/proxying"
 
+require "kredis/types/expirable"
 require "kredis/types/scalar"
 require "kredis/types/counter"
 require "kredis/types/cycle"

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -50,8 +50,8 @@ module Kredis::Types
     type_from(Flag, config, key, after_change: after_change, expires_in: expires_in)
   end
 
-  def enum(key, values:, default:, config: :shared, after_change: nil)
-    type_from(Enum, config, key, after_change: after_change, values: values, default: default)
+  def enum(key, values:, default:, config: :shared, after_change: nil, expires_at: nil, expires_in: nil)
+    type_from(Enum, config, key, after_change: after_change, values: values, default: default, expires_at: expires_at, expires_in: expires_in)
   end
 
   def hash(key, typed: :string, config: :shared, after_change: nil)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -38,9 +38,8 @@ module Kredis::Types
     type_from(Scalar, config, key, after_change: after_change, typed: :json, default: default, expires_in: expires_in)
   end
 
-
-  def counter(key, expires_in: nil, config: :shared, after_change: nil)
-    type_from(Counter, config, key, after_change: after_change, expires_in: expires_in)
+  def counter(key, expires_at: nil, expires_in: nil, config: :shared, after_change: nil)
+    type_from(Counter, config, key, after_change: after_change, expires_in: expires_in, expires_at: expires_at)
   end
 
   def cycle(key, values:, expires_in: nil, config: :shared, after_change: nil)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -42,8 +42,8 @@ module Kredis::Types
     type_from(Counter, config, key, after_change: after_change, expires_in: expires_in, expires_at: expires_at)
   end
 
-  def cycle(key, values:, expires_in: nil, config: :shared, after_change: nil)
-    type_from(Cycle, config, key, after_change: after_change, values: values, expires_in: expires_in)
+  def cycle(key, values:, expires_at: nil, expires_in: nil, config: :shared, after_change: nil)
+    type_from(Cycle, config, key, after_change: after_change, values: values, expires_in: expires_in, expires_at: expires_at)
   end
 
   def flag(key, config: :shared, after_change: nil, expires_in: nil)

--- a/lib/kredis/types/counter.rb
+++ b/lib/kredis/types/counter.rb
@@ -1,19 +1,21 @@
 class Kredis::Types::Counter < Kredis::Types::Proxying
-  proxying :multi, :set, :incrby, :decrby, :get, :del, :exists?
+  include Kredis::Types::Expirable
 
-  attr_accessor :expires_in
+  proxying :multi, :set, :incrby, :decrby, :get, :del, :exists?
 
   def increment(by: 1)
     multi do |pipeline|
-      pipeline.set 0, ex: expires_in, nx: true
+      pipeline.set 0, nx: true
       pipeline.incrby by
+      refresh_expiration
     end[-1]
   end
 
   def decrement(by: 1)
     multi do |pipeline|
-      pipeline.set 0, ex: expires_in, nx: true
+      pipeline.set 0, nx: true
       pipeline.decrby by
+      refresh_expiration
     end[-1]
   end
 

--- a/lib/kredis/types/cycle.rb
+++ b/lib/kredis/types/cycle.rb
@@ -1,4 +1,6 @@
 class Kredis::Types::Cycle < Kredis::Types::Counter
+  include Kredis::Types::Expirable.on(:next)
+
   attr_accessor :values
 
   alias index value

--- a/lib/kredis/types/enum.rb
+++ b/lib/kredis/types/enum.rb
@@ -1,6 +1,8 @@
 require "active_support/core_ext/object/inclusion"
 
 class Kredis::Types::Enum < Kredis::Types::Proxying
+  include Kredis::Types::Expirable.on(:value=)
+
   proxying :set, :get, :del, :exists?
 
   attr_accessor :values, :default

--- a/lib/kredis/types/expirable.rb
+++ b/lib/kredis/types/expirable.rb
@@ -1,0 +1,38 @@
+module Kredis::Types::Expirable
+  extend ActiveSupport::Concern
+
+  included do
+    proxying :expire, :expireat, :ttl
+
+    attr_accessor :expires_in, :expires_at
+
+    def expire_in(seconds)
+      expire seconds.to_i
+    end
+
+    def expire_at(datetime)
+      expireat datetime.to_i
+    end
+  end
+
+  def self.on(*on_methods)
+    Module.new do
+      define_singleton_method :included do |type_klass|
+        type_klass.include Kredis::Types::Expirable
+
+        type_klass.prepend(Module.new do
+          on_methods.each do |method|
+            define_method method do |*args|
+              super(*args)
+
+              expire_in(@expires_in) if expires_in
+              expire_at(@expires_at) if expires_at && !expires_in
+            end
+          end
+        end)
+      end
+    end
+  end
+end
+
+

--- a/lib/kredis/types/expirable.rb
+++ b/lib/kredis/types/expirable.rb
@@ -27,8 +27,8 @@ module Kredis::Types::Expirable
 
         type_klass.prepend(Module.new do
           on_methods.each do |method|
-            define_method method do |*args|
-              super(*args)
+            define_method method do |*args, **kargs, &block|
+              super(*args, **kargs, &block)
 
               refresh_expiration
             end

--- a/lib/kredis/types/expirable.rb
+++ b/lib/kredis/types/expirable.rb
@@ -13,6 +13,11 @@ module Kredis::Types::Expirable
     def expire_at(datetime)
       expireat datetime.to_i
     end
+
+    def refresh_expiration
+      expire_in(@expires_in) if expires_in
+      expire_at(@expires_at) if expires_at && !expires_in
+    end
   end
 
   def self.on(*on_methods)
@@ -25,8 +30,7 @@ module Kredis::Types::Expirable
             define_method method do |*args|
               super(*args)
 
-              expire_in(@expires_in) if expires_in
-              expire_at(@expires_at) if expires_at && !expires_in
+              refresh_expiration
             end
           end
         end)

--- a/lib/kredis/types/expirable.rb
+++ b/lib/kredis/types/expirable.rb
@@ -28,9 +28,11 @@ module Kredis::Types::Expirable
         type_klass.prepend(Module.new do
           on_methods.each do |method|
             define_method method do |*args, **kargs, &block|
-              super(*args, **kargs, &block)
+              operation_result = super(*args, **kargs, &block)
 
               refresh_expiration
+
+              operation_result
             end
           end
         end)

--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -1,6 +1,8 @@
 require "active_support/core_ext/hash"
 
 class Kredis::Types::Hash < Kredis::Types::Proxying
+  include Kredis::Types::Expirable.on(:[]=, :update, :delete)
+
   proxying :hget, :hset, :hmget, :hdel, :hgetall, :hkeys, :hvals, :del, :exists?
 
   attr_accessor :typed
@@ -13,7 +15,7 @@ class Kredis::Types::Hash < Kredis::Types::Proxying
     update key => value
   end
 
-  def update(**entries)
+  def update(entries)
     hset entries.transform_values{ |val| type_to_string(val, typed) } if entries.flatten.any?
   end
 

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -1,4 +1,6 @@
 class Kredis::Types::List < Kredis::Types::Proxying
+  include Kredis::Types::Expirable.on(:append, :prepend, :remove)
+
   proxying :lrange, :lrem, :lpush, :rpush, :exists?, :del
 
   attr_accessor :typed

--- a/test/types/counter_test.rb
+++ b/test/types/counter_test.rb
@@ -43,20 +43,18 @@ class CounterTest < ActiveSupport::TestCase
     assert_equal (-4), @counter.decrement(by: 2)
   end
 
-  test "expiring counter" do
-    @counter = Kredis.counter "mycounter", expires_in: 1.second
+  test "with expires in" do
+    @counter = Kredis.counter "mycounter", expires_in: 25.second
 
     @counter.increment
-    assert_equal 1, @counter.value
+    assert @counter.ttl.between?(20, 25)
+  end
 
-    sleep 0.5.seconds
+  test "with expires at" do
+    @counter = Kredis.counter "mycounter", expires_at: Time.current + 25.second
 
     @counter.increment
-    assert_equal 2, @counter.value
-
-    sleep 0.6.seconds
-
-    assert_equal 0, @counter.value
+    assert @counter.ttl.between?(20, 25)
   end
 
   test "reset" do

--- a/test/types/cycle_test.rb
+++ b/test/types/cycle_test.rb
@@ -17,6 +17,20 @@ class CycleTest < ActiveSupport::TestCase
     assert_equal :one, @cycle.value
   end
 
+  test "with expires_in" do
+    @cycle = Kredis.cycle "mycycle", values: %i[ one two ], expires_in: 25.seconds
+    @cycle.next
+
+    assert @cycle.ttl.between?(20, 25)
+  end
+
+  test "with expires_at" do
+    @cycle = Kredis.cycle "mycycle", values: %i[ one two ], expires_at: Time.current + 25.seconds
+    @cycle.next
+
+    assert @cycle.ttl.between?(20, 25)
+  end
+
   test "failing open" do
     stub_redis_down(@cycle) { @cycle.next }
     assert_equal :one, @cycle.value

--- a/test/types/enum_test.rb
+++ b/test/types/enum_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "active_support/core_ext/integer"
 
 class EnumTest < ActiveSupport::TestCase
   setup { @enum = Kredis.enum "myenum", values: %w[ one two three ], default: "one" }
@@ -26,6 +27,20 @@ class EnumTest < ActiveSupport::TestCase
 
     @enum.value = "nonesense"
     assert @enum.one?
+  end
+
+  test "with expires_in" do
+    @enum = Kredis.enum "myenum", values: %w[ one ], default: "one", expires_in: 25.seconds
+    @enum.value = "one"
+
+    assert @enum.ttl.between?(20, 25)
+  end
+
+  test "with expires_at" do
+    @enum = Kredis.enum "myenum", values: %w[ one ], default: "one", expires_at: Time.current + 25.seconds
+    @enum.value = "one"
+
+    assert @enum.ttl.between?(20, 25)
   end
 
   test "reset" do

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -15,12 +15,37 @@ class HashTest < ActiveSupport::TestCase
     @hash[:key]  = :value
     @hash[:key2] = "value2"
     assert_equal({ "key" => "value", "key2" => "value2" }, @hash.to_h)
+    assert_equal(-1, @hash.ttl)
+  end
+
+  test "[]= assigment with expires_in" do
+    @hash.expires_in = 25
+    @hash[:key] = :value
+    assert(@hash.ttl.between?(20, 25))
+  end
+
+  test "[]= assigment with expires_at" do
+    @hash.expires_at = Time.current + 25.seconds
+    @hash[:key] = :value
+    assert(@hash.ttl.between?(20, 25))
   end
 
   test "update" do
     @hash.update(key: :value)
     @hash.update("key2" => "value2", "key3" => "value3")
     assert_equal({ "key" => "value", "key2" => "value2", "key3" => "value3" }, @hash.to_h)
+  end
+
+  test "update with expires_in" do
+    @hash.expires_in = 25
+    @hash.update("key2" => "value2")
+    assert(@hash.ttl.between?(20, 25))
+  end
+
+  test "update with expires_at" do
+    @hash.expires_at = Time.current + 25.seconds
+    @hash.update("key2" => "value2")
+    assert(@hash.ttl.between?(20, 25))
   end
 
   test "values_at" do
@@ -38,6 +63,24 @@ class HashTest < ActiveSupport::TestCase
 
     @hash.delete("key2", "key3")
     assert_equal({}, @hash.to_h)
+  end
+
+  test "delete with expires_in" do
+    @hash.update("key2" => "value2", "key3" => "value3")
+    assert_equal(-1, @hash.ttl)
+
+    @hash.expires_in = 25
+    @hash.delete("key2")
+    assert(@hash.ttl.between?(20, 25))
+  end
+
+  test "delete with expires_at" do
+    @hash.update("key2" => "value2", "key3" => "value3")
+    assert_equal(-1, @hash.ttl)
+
+    @hash.expires_at = Time.current + 25.seconds
+    @hash.delete("key2")
+    assert(@hash.ttl.between?(20, 25))
   end
 
   test "entries" do

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -8,6 +8,13 @@ class ListTest < ActiveSupport::TestCase
     @list.append(%w[ 1 2 3 ])
     @list << 4
     assert_equal %w[ 1 2 3 4 ], @list.elements
+    assert_equal -1, @list.ttl
+  end
+
+  test "append with expires_in" do
+    @list.expires_in = 25
+    @list.append(%w[ 1 2 3 ])
+    assert @list.ttl.between?(20, 25)
   end
 
   test "append nothing" do
@@ -22,6 +29,12 @@ class ListTest < ActiveSupport::TestCase
     assert_equal %w[ 4 3 2 1 ], @list.elements
   end
 
+  test "prepend with expires_in" do
+    @list.expires_in = 25
+    @list.prepend(%w[ 1 2 3 ])
+    assert @list.ttl.between?(20, 25)
+  end
+
   test "prepend nothing" do
     @list.prepend("1", "2", "3")
     @list.prepend([])
@@ -33,6 +46,15 @@ class ListTest < ActiveSupport::TestCase
     @list.remove(%w[ 1 2 ])
     @list.remove(3)
     assert_equal %w[ 4 ], @list.elements
+  end
+
+  test "remove with expires_in" do
+    @list.append(%w[ 1 2 3 4 ])
+    assert_equal -1, @list.ttl
+
+    @list.expires_in = 25
+    @list.remove(%w[ 1 2 ])
+    assert @list.ttl.between?(20, 25)
   end
 
   test "clear" do


### PR DESCRIPTION
Hello,

I need the expire feature for hash and saw some work done on expiring lists and unique lists. See #86. I thought about extending the expiration capability to any type. Perhaps it is valuable to others.

Here is a POC. I added the `Expirable` module to `List` and `Hash` to showcase.

When it has one, executing the expire under the `pipeline` is still missing (a problem we wouldn't need to deal with if we abstract the pipeline like #78 does).

Besides that, it could also make `expires_in` and `expires_at` inside `options` in the upstream API. Would it also make things easier?

Is it worth it to keep working here? @jorgemanrubia, do you mind reviewing it?

Thanks.