### PR TITLE
Permit disabling fail safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ You can configure how the redis client is created by setting `config.kredis.conn
 config.kredis.connector = ->(config) { SomeRedisProxy.new(config) }
 ```
 
-The fail safe mechanism supports silently rescuing or returning a default value in the event that the Redis client returns an error (e.g. Redis is down). You can disable the default fail safe mechanism:
+The fail-safe mechanism supports silently rescuing or returning a default value in the event that the Redis client returns an error (e.g. Redis is down). You can disable the default fail-safe mechanism:
 
 ```ruby
 config.kredis.fail_safe = false

--- a/README.md
+++ b/README.md
@@ -241,12 +241,18 @@ Kredis::Connections.connections[:shared] = Redis.new(
 
 The above code could be added to either `config/environments/production.rb` or an initializer. Please ensure that your client private key, if used, is stored your credentials file or another secure location.
 
-### Configure how the redis client is created
+### Configuration
 
 You can configure how the redis client is created by setting `config.kredis.connector` in your `application.rb`:
 
 ```ruby
 config.kredis.connector = ->(config) { SomeRedisProxy.new(config) }
+```
+
+The fail safe mechanism supports silently rescuing or returning a default value in the event that the Redis client returns an error (e.g. Redis is down). You can disable the default fail safe mechanism:
+
+```ruby
+config.kredis.fail_safe = false
 ```
 
 By default Kredis will use `Redis.new(config)`.

--- a/lib/kredis/railtie.rb
+++ b/lib/kredis/railtie.rb
@@ -15,8 +15,8 @@ class Kredis::Railtie < ::Rails::Railtie
   initializer "kredis.configuration" do
     Kredis::Connections.connector = config.kredis.connector || ->(config) { Redis.new(config) }
 
-    if config.kredis.failsafe.present?
-      Kredis::Types::Proxy::Failsafe.failsafe_enabled = !!config.kredis.failsafe
+    unless config.kredis.failsafe.nil? do
+      Kredis::Types::Proxy::Failsafe.failsafe_enabled = config.kredis.failsafe
     end
   end
 

--- a/lib/kredis/railtie.rb
+++ b/lib/kredis/railtie.rb
@@ -14,6 +14,10 @@ class Kredis::Railtie < ::Rails::Railtie
 
   initializer "kredis.configuration" do
     Kredis::Connections.connector = config.kredis.connector || ->(config) { Redis.new(config) }
+
+    if config.kredis.failsafe.present?
+      Kredis::Types::Proxy::Failsafe.failsafe_enabled = !!config.kredis.failsafe
+    end
   end
 
   initializer "kredis.configurator" do

--- a/lib/kredis/railtie.rb
+++ b/lib/kredis/railtie.rb
@@ -16,7 +16,7 @@ class Kredis::Railtie < ::Rails::Railtie
     Kredis::Connections.connector = config.kredis.connector || ->(config) { Redis.new(config) }
 
     unless config.kredis.failsafe.nil? do
-      Kredis::Types::Proxy::Failsafe.failsafe_enabled = config.kredis.failsafe
+      Kredis::Types::Proxy::Failsafe.enabled = config.kredis.failsafe
     end
   end
 

--- a/lib/kredis/railtie.rb
+++ b/lib/kredis/railtie.rb
@@ -15,8 +15,8 @@ class Kredis::Railtie < ::Rails::Railtie
   initializer "kredis.configuration" do
     Kredis::Connections.connector = config.kredis.connector || ->(config) { Redis.new(config) }
 
-    unless config.kredis.failsafe.nil? do
-      Kredis::Types::Proxy::Failsafe.enabled = config.kredis.failsafe
+    unless config.kredis.fail_safe.nil? do
+      Kredis::Types::Proxy::Failsafe.enabled = config.kredis.fail_safe
     end
   end
 

--- a/lib/kredis/types/proxy/failsafe.rb
+++ b/lib/kredis/types/proxy/failsafe.rb
@@ -1,12 +1,10 @@
 module Kredis::Types::Proxy::Failsafe
   extend ActiveSupport::Concern
 
-  included do
-    mattr_accessor :fail_safe_enabled, default: true
-  end
+  mattr_accessor :enabled, default: true
 
   def failsafe(returning: nil, &block)
-    if fail_safe_enabled? && !fail_safe_suppressed?
+    if enabled? && !suppressed?
       rescue_redis_errors_with(returning: returning, &block)
     else
       yield
@@ -14,20 +12,20 @@ module Kredis::Types::Proxy::Failsafe
   end
 
   private
-    def fail_safe_enabled?
-      fail_safe_enabled
+    def enabled?
+      enabled
     end
 
-    def fail_safe_suppressed?
-      @fail_safe_suppressed
+    def suppressed?
+      @suppressed
     end
 
     def rescue_redis_errors_with(returning: nil)
-      old_fail_safe_suppressed, @fail_safe_suppressed = @fail_safe_suppressed, true
+      old_suppressed, @suppressed = @suppressed, true
       yield
     rescue Redis::BaseError
       returning
     ensure
-      @fail_safe_suppressed = old_fail_safe_suppressed
+      @suppressed = old_suppressed
     end
 end

--- a/lib/kredis/types/proxy/failsafe.rb
+++ b/lib/kredis/types/proxy/failsafe.rb
@@ -1,26 +1,33 @@
 module Kredis::Types::Proxy::Failsafe
-  def initialize(*)
-    super
-    @fail_safe_suppressed = false
+  extend ActiveSupport::Concern
+
+  included do
+    mattr_accessor :fail_safe_enabled, default: true
   end
 
-  def failsafe
-    yield
-  rescue Redis::BaseError
-    raise if fail_safe_suppressed?
-  end
-
-  def suppress_failsafe_with(returning: nil)
-    old_fail_safe_suppressed, @fail_safe_suppressed = @fail_safe_suppressed, true
-    yield
-  rescue Redis::BaseError
-    returning
-  ensure
-    @fail_safe_suppressed = old_fail_safe_suppressed
+  def failsafe(returning: nil, &block)
+    if fail_safe_enabled? && !fail_safe_suppressed?
+      rescue_redis_errors_with(returning: returning, &block)
+    else
+      yield
+    end
   end
 
   private
+    def fail_safe_enabled?
+      fail_safe_enabled
+    end
+
     def fail_safe_suppressed?
       @fail_safe_suppressed
+    end
+
+    def rescue_redis_errors_with(returning: nil)
+      old_fail_safe_suppressed, @fail_safe_suppressed = @fail_safe_suppressed, true
+      yield
+    rescue Redis::BaseError
+      returning
+    ensure
+      @fail_safe_suppressed = old_fail_safe_suppressed
     end
 end

--- a/lib/kredis/types/proxying.rb
+++ b/lib/kredis/types/proxying.rb
@@ -3,6 +3,8 @@ require "active_support/core_ext/module/delegation"
 class Kredis::Types::Proxying
   attr_accessor :proxy, :key
 
+  delegate :failsafe, to: :proxy
+
   def self.proxying(*commands)
     delegate *commands, to: :proxy
   end
@@ -11,10 +13,6 @@ class Kredis::Types::Proxying
     @key = key
     @proxy = Kredis::Types::Proxy.new(redis, key)
     options.each { |key, value| send("#{key}=", value) }
-  end
-
-  def failsafe(returning: nil, &block)
-    proxy.suppress_failsafe_with(returning: returning, &block)
   end
 
   private

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class ProxyTest < ActiveSupport::TestCase
   setup { @proxy = Kredis.proxy "something" }
+  teardown { @proxy.fail_safe_enabled = true }
 
   test "proxy set and get and del" do
     @proxy.set "one"
@@ -26,7 +27,5 @@ class ProxyTest < ActiveSupport::TestCase
     stub_redis_down(@proxy) do
       assert_raises(Redis::BaseError) { @proxy.get }
     end
-
-    @proxy.fail_safe_enabled = true
   end
 end

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ProxyTest < ActiveSupport::TestCase
   setup { @proxy = Kredis.proxy "something" }
-  teardown { @proxy.fail_safe_enabled = true }
+  teardown { Kredis::Types::Proxy::Failsafe.enabled = true }
 
   test "proxy set and get and del" do
     @proxy.set "one"
@@ -22,7 +22,7 @@ class ProxyTest < ActiveSupport::TestCase
   end
 
   test "with fail safe disabled an error is raised" do
-    @proxy.fail_safe_enabled = false
+    Kredis::Types::Proxy::Failsafe.enabled = false
 
     stub_redis_down(@proxy) do
       assert_raises(Redis::BaseError) { @proxy.get }

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -19,4 +19,14 @@ class ProxyTest < ActiveSupport::TestCase
     assert @proxy.set("two")
     stub_redis_down(@proxy) { assert_nil @proxy.set("two") }
   end
+
+  test "with fail safe disabled an error is raised" do
+    @proxy.fail_safe_enabled = false
+
+    stub_redis_down(@proxy) do
+      assert_raises(Redis::BaseError) { @proxy.get }
+    end
+
+    @proxy.fail_safe_enabled = true
+  end
 end


### PR DESCRIPTION
Makes the fail safe mechanism optional. When fail safe is disabled, errors will be raised as per usual.

This covers scenarios where the global fail safe is undesirable.

**Usage**

```ruby
config.kredis.fail_safe = false
```