### PR TITLE
Add `last` to lists

### DIFF
--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -26,16 +26,6 @@ class Kredis::Types::List < Kredis::Types::Proxying
   end
 
   def last(n = nil)
-    if n
-      if n == 0
-        []
-      elsif n < 0
-        raise ArgumentError, "negative array size"
-      else
-        lrange(-n, -1)
-      end
-    else
-      lrange(-1, -1).first
-    end
+    n ? lrange(-n, -1) : lrange(-1, -1).first
   end
 end

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -24,4 +24,18 @@ class Kredis::Types::List < Kredis::Types::Proxying
   def clear
     del
   end
+
+  def last(n = nil)
+    if n
+      if n == 0
+        []
+      elsif n < 0
+        raise ArgumentError, "negative array size"
+      else
+        lrange(-n, -1)
+      end
+    else
+      lrange(-1, -1).first
+    end
+  end
 end

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -41,6 +41,18 @@ class ListTest < ActiveSupport::TestCase
     assert_equal [], @list.elements
   end
 
+  test "last" do
+    @list.append(%w[ 1 2 3 ])
+    assert_equal "3", @list.last
+  end
+
+  test "last(n)" do
+    @list.append(%w[ 1 2 3 ])
+    assert_equal %w[ 2 3 ], @list.last(2)
+    assert_equal [], @list.last(0)
+    assert_raises(ArgumentError) { @list.last(-2) }
+  end
+
   test "typed as datetime" do
     @list = Kredis.list "mylist", typed: :datetime
 

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -49,8 +49,6 @@ class ListTest < ActiveSupport::TestCase
   test "last(n)" do
     @list.append(%w[ 1 2 3 ])
     assert_equal %w[ 2 3 ], @list.last(2)
-    assert_equal [], @list.last(0)
-    assert_raises(ArgumentError) { @list.last(-2) }
   end
 
   test "typed as datetime" do


### PR DESCRIPTION
This adds support for `last` for lists. Both `last` and `last(n)` are supported.

Because Ruby doesn't provide a great way to replicate the implicit conversions (`Integer.try_convert` exists in Ruby 3.1, but we'd still need to generate the error message manually because it returns `nil` instead of raising the `TypeError`), some edge cases of the implementation of `Array#last` are not replicated:
- `[].last(nil)` raises a `TypeError`, whereas we just fail with <code>undefined method `to_int' for nil:NilClass (NoMethodError)</code>
- `[].last(object)` where `object.to_int` doesn't return an `Integer` raises a `TypeError`, whereas we will call `==` and `<` on `object`, and the results may be unexpected (though that is a really edgy case).

The first commit is really the most straightforward implementation, and we may not need the second one if we don't care about the edge case of `nil` or `false` being passed and expecting an exception. I think in most cases `last(n)` is called with a literal value, so it's fine.