### PR TITLE
Address LogSubscriber deprecation

### DIFF
--- a/lib/kredis/log_subscriber.rb
+++ b/lib/kredis/log_subscriber.rb
@@ -15,7 +15,7 @@ class Kredis::LogSubscriber < ActiveSupport::LogSubscriber
 
   private
     def formatted_in(color, event, type: nil)
-      color "  Kredis #{type} (#{event.duration.round(1)}ms)  #{event.payload[:message]}", color, true
+      color "  Kredis #{type} (#{event.duration.round(1)}ms)  #{event.payload[:message]}", color, bold: true
     end
 end
 


### PR DESCRIPTION
As of https://github.com/rails/rails/pull/45976, `ActiveSupport::LogSubscriber` expects a kwarg to make text bold.

> DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color(:red, "my text", bold: true)`).