### PR TITLE
Add `sample` to set

### DIFF
--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -1,5 +1,5 @@
 class Kredis::Types::Set < Kredis::Types::Proxying
-  proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop, :exists?
+  proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop, :exists?, :srandmember
 
   attr_accessor :typed
 
@@ -38,5 +38,13 @@ class Kredis::Types::Set < Kredis::Types::Proxying
 
   def clear
     del
+  end
+
+  def sample(count = nil)
+    if count.nil?
+      string_to_type(srandmember(count), typed)
+    else
+      strings_to_types(srandmember(count), typed)
+    end
   end
 end

--- a/test/types/set_test.rb
+++ b/test/types/set_test.rb
@@ -88,4 +88,12 @@ class SetTest < ActiveSupport::TestCase
     @set.add(%w[ 1 2 3 ])
     assert @set.exists?
   end
+
+  test "srandmember" do
+    @set = Kredis.set "mylist", typed: :float
+    @set.add 1.5, 2.7
+
+    assert @set.sample.in?([ 1.5, 2.7 ])
+    assert_equal [ 1.5, 2.7 ], @set.sample(2).sort
+  end
 end


### PR DESCRIPTION
Add `sample` to set, which uses `SRANDMEMBER` in redis. So we can use `Set#sample` like `Array`.
```ruby
set = Kredis.set "myset", typed: :integer
set.add([1, 2, 3, 4, 5])
set.sample # 3, maybe
set.sample(1) # [3]
set.sample(10) # [1, 2, 3, 4, 5]
```

[Redis Doc](https://redis.io/commands/srandmember/)