### PR TITLE
Account for time zones in DateTime serializations

### DIFF
--- a/lib/kredis/type/datetime.rb
+++ b/lib/kredis/type/datetime.rb
@@ -4,7 +4,7 @@ module Kredis
   module Type
     class DateTime < ActiveModel::Type::DateTime
       def serialize(value)
-        super&.iso8601(9)
+        super&.utc&.iso8601(9)
       end
 
       def cast_value(value)

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -44,7 +44,7 @@ class ListTest < ActiveSupport::TestCase
   test "typed as datetime" do
     @list = Kredis.list "mylist", typed: :datetime
 
-    @list.append [ 1.day.from_now.midnight, 2.days.from_now.midnight ]
+    @list.append [ 1.day.from_now.midnight.in_time_zone("Pacific Time (US & Canada)"), 2.days.from_now.midnight.in_time_zone("UTC") ]
     assert_equal [ 1.day.from_now.midnight, 2.days.from_now.midnight ], @list.elements
 
     @list.remove(2.days.from_now.midnight)


### PR DESCRIPTION
# Issue

Fixes https://github.com/rails/kredis/issues/101.

# Overview

This PR fixes an issue with DateTime serializations where time zones could break string equality checks if DateTimes with differing time zones get serialized. As mentioned in the issue above, I was able to produce an error using the following in a Rails console:

> Here's some code that I ran in a Rails console to replicate:
> 
> ```ruby
> datetime_list = Kredis.list("testing", typed: :datetime)
> datetime_list.append([1.minute.ago, 1.hour.ago, 1.day.ago])
> datetime_list.remove(datetime_list.elements.first)
> datetime_list.elements #=> Still has 3 elements
> ```
> 
> This works if I don't specify typed:
> 
> ```ruby
> datetime_list = Kredis.list("testing")
> datetime_list.append([1.minute.ago, 1.hour.ago, 1.day.ago])
> datetime_list.remove(datetime_list.elements.first)
> datetime_list.elements #=> Only has 2 elements, so it worked!
> ```

After digging into the source code a bit, I realized that Kredis::Type::DateTime was always serializing to a string, which could produce different results for the same DateTime depending on the set time zone.

My proposed solution here is to convert DateTime instances to UTC before serialization so that strings get compared in the context of UTC. I thought this should be acceptable since it will still be able to read existing values from Redis without problem and perform operations on them.

The first commit produces a red test. The second commit gets it green.