### PR TITLE
Typecast return of Set#take

### DIFF
--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -33,7 +33,7 @@ class Kredis::Types::Set < Kredis::Types::Proxying
   end
 
   def take
-    spop
+    string_to_type(spop, typed)
   end
 
   def clear

--- a/test/types/set_test.rb
+++ b/test/types/set_test.rb
@@ -72,6 +72,8 @@ class SetTest < ActiveSupport::TestCase
 
     @set.remove(2.7)
     assert_equal [ 1.5 ], @set.members
+
+    assert_equal 1.5, @set.take
   end
 
   test "failing open" do


### PR DESCRIPTION
Otherwise it's always a string.