### PR TITLE
Return Time objects instead of deprecated DateTime

### DIFF
--- a/lib/kredis/type/datetime.rb
+++ b/lib/kredis/type/datetime.rb
@@ -8,7 +8,7 @@ module Kredis
       end
 
       def cast_value(value)
-        super&.to_datetime
+        super&.to_time
       end
     end
   end

--- a/test/types/scalar_test.rb
+++ b/test/types/scalar_test.rb
@@ -53,7 +53,7 @@ class ScalarTest < ActiveSupport::TestCase
   test "datetime casting Dates" do
     datetime = Kredis.datetime "myscalar"
     datetime.value = Date.current
-    assert_equal Date.current.to_datetime, datetime.value
+    assert_equal Date.current.to_time, datetime.value
   end
 
   test "json" do


### PR DESCRIPTION
Time is preferred for current dates and times. DateTime is considered deprecated since Ruby 3.0: https://ruby-doc.org/stdlib-3.0.0/libdoc/date/rdoc/DateTime.html

Mixing the two can lead to confusing situations as shown in this gist: https://gist.github.com/bdewater/4c483beb7f521841a915f62c56fdcea4 