### PR TITLE
Declare Active Model dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     kredis (1.3.0)
+      activemodel (>= 6.0.0)
       activesupport (>= 6.0.0)
       redis (>= 4.2, < 6)
 

--- a/kredis.gemspec
+++ b/kredis.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
   s.add_dependency "activesupport", ">= 6.0.0"
+  s.add_dependency "activemodel", ">= 6.0.0"
   s.add_dependency "redis", ">= 4.2", "< 6"
   s.add_development_dependency "rails", ">= 6.0.0"
 


### PR DESCRIPTION
[`type_casting.rb`](https://github.com/rails/kredis/blob/main/lib/kredis/type_casting.rb) requires "active_model/type". This seems to have been missed as part of #22.