### PR TITLE
CI against Redis 7, Ruby 3.1, and Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Redis server ${{ matrix.redis_server }} - Ruby ${{ matrix.ruby }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        redis_server: ["4", "5", "6.2"]
-        ruby: ["2.7", "3.0"]
+        redis_server: ["4", "5", "6", "7"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
 
     name: Redis server ${{ matrix.redis_server }} - Ruby ${{ matrix.ruby }}
 


### PR DESCRIPTION
This patch adds Redis 7, Ruby 3.1, and Ruby 3.2 to the CI matrix.

Plus, eliminates a node 12 deprecation warning by updating actions/checkout from v2 to v3.