### PR TITLE
Fix ordered set prepend bug

### DIFF
--- a/lib/kredis/types/ordered_set.rb
+++ b/lib/kredis/types/ordered_set.rb
@@ -34,7 +34,13 @@ class Kredis::Types::OrderedSet < Kredis::Types::Proxying
       return if elements.empty?
 
       elements_with_scores = types_to_strings(elements, typed).map.with_index do |element, index|
-        score = generate_base_score(negative: prepending) + (index / 100000)
+        incremental_score = index * 0.000001
+
+        score = if prepending
+          -base_score - incremental_score
+        else
+          base_score + incremental_score
+        end
 
         [ score , element ]
       end
@@ -45,10 +51,8 @@ class Kredis::Types::OrderedSet < Kredis::Types::Proxying
       end
     end
 
-    def generate_base_score(negative:)
-      current_time = process_start_time + process_uptime
-
-      negative ? -current_time : current_time
+    def base_score
+      process_start_time + process_uptime
     end
 
     def process_start_time


### PR DESCRIPTION
Addresses https://github.com/rails/kredis/pull/114#issuecomment-1597173673

The scoring for prepended elements was not being calculated correctly. It needs to decrement the score by 0.000001 for each element. Previously it was adding that amount, but because the base score was decreasing the bug was not exposed.

The scoring tolerated this change as we rely on process uptime monotonically increasing as well as the element index.

Using Ruby 3.2.2 locally performance seems to be much improved, exposing this bug.

