### PR TITLE
Add kredis_ordered_set for OrderedSet usage in models

### DIFF
--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -50,6 +50,10 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, limit: limit, typed: typed, config: config, after_change: after_change
     end
 
+    def kredis_ordered_set(name, limit: nil, key: nil, typed: :string, config: :shared, after_change: nil)
+      kredis_connection_with __method__, name, key, limit: limit, typed: typed, config: config, after_change: after_change
+    end
+
     def kredis_set(name, key: nil, typed: :string, config: :shared, after_change: nil)
       kredis_connection_with __method__, name, key, typed: typed, config: config, after_change: after_change
     end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -11,6 +11,7 @@ class Person
   kredis_list :names_with_custom_key_via_lambda, key: ->(p) { "person:#{p.id}:names_customized" }
   kredis_list :names_with_custom_key_via_method, key: :generate_key
   kredis_unique_list :skills, limit: 2
+  kredis_ordered_set :reading_list, limit: 2
   kredis_flag :special
   kredis_flag :temporary_special, expires_in: 1.second
   kredis_string :address
@@ -88,6 +89,11 @@ class AttributesTest < ActiveSupport::TestCase
     @person.skills.prepend("racing")
     @person.skills.prepend("racing")
     assert_equal %w[ racing photography ], @person.skills.elements
+  end
+
+  test "ordered set" do
+    @person.reading_list.prepend(%w[ rework shapeup remote ])
+    assert_equal %w[ remote shapeup ], @person.reading_list.elements
   end
 
   test "flag" do


### PR DESCRIPTION
Follows https://github.com/rails/kredis/pull/114 with support for declaring OrderedSet usage in a model.