### PR TITLE
Set up RuboCop with CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,22 @@
+name: RuboCop
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Ruby 3.2
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+        bundler-cache: true
+
+    - name: Run RuboCop
+      run: bundle exec rubocop --parallel

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 .byebug_history
+.rubocop-*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: https://raw.githubusercontent.com/rails/rails/main/.rubocop.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,9 @@ gemspec
 
 gem "rake"
 gem "byebug"
+gem "rubocop"
+gem "rubocop-minitest"
+gem "rubocop-packaging"
+gem "rubocop-performance"
+gem "rubocop-rails"
+gem "rubocop-md"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    ast (2.4.2)
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.1.8)
@@ -78,6 +79,8 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -96,6 +99,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.2-x86_64-darwin)
       racc (~> 1.4)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
     racc (1.7.1)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -126,11 +133,41 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (~> 1.0)
+    rainbow (3.1.1)
     rake (13.0.3)
     redis (5.0.6)
       redis-client (>= 0.9.0)
     redis-client (0.14.1)
       connection_pool
+    regexp_parser (2.8.1)
+    rexml (3.2.5)
+    rubocop (1.54.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.3)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    rubocop-md (1.2.0)
+      rubocop (>= 1.0)
+    rubocop-minitest (0.31.0)
+      rubocop (>= 1.39, < 2.0)
+    rubocop-packaging (0.5.2)
+      rubocop (>= 1.33, < 2.0)
+    rubocop-performance (1.18.0)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.20.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
+    ruby-progressbar (1.13.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -141,6 +178,7 @@ GEM
     thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (2.4.2)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -156,6 +194,12 @@ DEPENDENCIES
   kredis!
   rails (>= 6.0.0)
   rake
+  rubocop
+  rubocop-md
+  rubocop-minitest
+  rubocop-packaging
+  rubocop-performance
+  rubocop-rails
 
 BUNDLED WITH
    2.3.12

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ integer.value = 5  # => SET myinteger "5"
 5 == integer.value # => GET myinteger
 
 decimal = Kredis.decimal "mydecimal" # accuracy!
-decimal.value = "%.47f" % (1.0/10) # => SET mydecimal "0.10000000000000000555111512312578270211815834045"
+decimal.value = "%.47f" % (1.0 / 10) # => SET mydecimal "0.10000000000000000555111512312578270211815834045"
 BigDecimal("0.10000000000000000555111512312578270211815834045e0") == decimal.value # => GET mydecimal
 
 float = Kredis.float "myfloat" # speed!
-float.value = 1.0/10 # => SET myfloat "0.1"
+float.value = 1.0 / 10 # => SET myfloat "0.1"
 0.1 == float.value # => GET myfloat
 
 boolean = Kredis.boolean "myboolean"
@@ -228,14 +228,14 @@ If you need to connect to Redis with SSL, the recommended approach is to set you
 
 ```ruby
 Kredis::Connections.connections[:shared] = Redis.new(
-  url: ENV['REDIS_URL'],
+  url: ENV["REDIS_URL"],
   ssl_params: {
     cert_store: OpenSSL::X509::Store.new.tap { |store|
-      store.add_file(Rails.root.join('config', 'ca_cert.pem').to_s)
+      store.add_file(Rails.root.join("config", "ca_cert.pem").to_s)
     },
 
     cert: OpenSSL::X509::Certificate.new(File.read(
-      Rails.root.join('config', 'client.crt')
+      Rails.root.join("config", "client.crt")
     )),
 
     key: OpenSSL::PKey::RSA.new(

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "irb"
 require "bundler/inline"

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 $: << File.expand_path("../test", __dir__)
 
 require "bundler/setup"

--- a/kredis.gemspec
+++ b/kredis.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/kredis/version"
 
 Gem::Specification.new do |s|

--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 yaml_path = Rails.root.join("config/redis/shared.yml")
 unless yaml_path.exist?
   say "Adding `config/redis/shared.yml`"

--- a/lib/kredis.rb
+++ b/lib/kredis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/module/attribute_accessors_per_thread"

--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kredis::Attributes
   extend ActiveSupport::Concern
 
@@ -106,7 +108,7 @@ module Kredis::Attributes
     end
 
     def kredis_key_for_attribute(name)
-      "#{self.class.name.tableize.gsub("/", ":")}:#{extract_kredis_id}:#{name}"
+      "#{self.class.name.tableize.tr("/", ":")}:#{extract_kredis_id}:#{name}"
     end
 
     def extract_kredis_id

--- a/lib/kredis/connections.rb
+++ b/lib/kredis/connections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "redis"
 
 module Kredis::Connections
@@ -6,11 +8,9 @@ module Kredis::Connections
   mattr_accessor :connector, default: ->(config) { Redis.new(config) }
 
   def configured_for(name)
-    connections[name] ||= begin
-      Kredis.instrument :meta, message: "Connected to #{name}" do
+    connections[name] ||= Kredis.instrument :meta, message: "Connected to #{name}" do
         connector.call configurator.config_for("redis/#{name}")
       end
-    end
   end
 
   def clear_all

--- a/lib/kredis/log_subscriber.rb
+++ b/lib/kredis/log_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/log_subscriber"
 
 class Kredis::LogSubscriber < ActiveSupport::LogSubscriber

--- a/lib/kredis/migration.rb
+++ b/lib/kredis/migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/delegation"
 
 class Kredis::Migration

--- a/lib/kredis/namespace.rb
+++ b/lib/kredis/namespace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kredis::Namespace
   def namespace=(namespace)
     Thread.current[:kredis_namespace] = namespace

--- a/lib/kredis/railtie.rb
+++ b/lib/kredis/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Railtie < ::Rails::Railtie
   config.kredis = ActiveSupport::OrderedOptions.new
 

--- a/lib/kredis/type_casting.rb
+++ b/lib/kredis/type_casting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "json"
 require "active_model/type"
 require "kredis/type/json"

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kredis::Types
   autoload :CallbacksProxy, "kredis/types/callbacks_proxy"
 

--- a/lib/kredis/types/callbacks_proxy.rb
+++ b/lib/kredis/types/callbacks_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::CallbacksProxy
   attr_reader :type
   delegate :to_s, to: :type

--- a/lib/kredis/types/counter.rb
+++ b/lib/kredis/types/counter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::Counter < Kredis::Types::Proxying
   proxying :multi, :set, :incrby, :decrby, :get, :del, :exists?
 

--- a/lib/kredis/types/cycle.rb
+++ b/lib/kredis/types/cycle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::Cycle < Kredis::Types::Counter
   attr_accessor :values
 

--- a/lib/kredis/types/enum.rb
+++ b/lib/kredis/types/enum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/object/inclusion"
 
 class Kredis::Types::Enum < Kredis::Types::Proxying

--- a/lib/kredis/types/flag.rb
+++ b/lib/kredis/types/flag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::Flag < Kredis::Types::Proxying
   proxying :set, :exists?, :del
 

--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/hash"
 
 class Kredis::Types::Hash < Kredis::Types::Proxying
@@ -14,7 +16,7 @@ class Kredis::Types::Hash < Kredis::Types::Proxying
   end
 
   def update(**entries)
-    hset entries.transform_values{ |val| type_to_string(val, typed) } if entries.flatten.any?
+    hset entries.transform_values { |val| type_to_string(val, typed) } if entries.flatten.any?
   end
 
   def values_at(*keys)

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::List < Kredis::Types::Proxying
   proxying :lrange, :lrem, :lpush, :ltrim, :rpush, :exists?, :del
 

--- a/lib/kredis/types/ordered_set.rb
+++ b/lib/kredis/types/ordered_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::OrderedSet < Kredis::Types::Proxying
   proxying :multi, :zrange, :zrem, :zadd, :zremrangebyrank, :zcard, :exists?, :del
 
@@ -42,7 +44,7 @@ class Kredis::Types::OrderedSet < Kredis::Types::Proxying
           base_score + incremental_score
         end
 
-        [ score , element ]
+        [ score, element ]
       end
 
       multi do

--- a/lib/kredis/types/proxy.rb
+++ b/lib/kredis/types/proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::Proxy
   require_relative "proxy/failsafe"
   include Failsafe

--- a/lib/kredis/types/proxy/failsafe.rb
+++ b/lib/kredis/types/proxy/failsafe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kredis::Types::Proxy::Failsafe
   def initialize(*)
     super

--- a/lib/kredis/types/proxying.rb
+++ b/lib/kredis/types/proxying.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/delegation"
 
 class Kredis::Types::Proxying

--- a/lib/kredis/types/scalar.rb
+++ b/lib/kredis/types/scalar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::Scalar < Kredis::Types::Proxying
   proxying :set, :get, :exists?, :del, :expire, :expireat
 

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::Set < Kredis::Types::Proxying
   proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop, :exists?, :srandmember
 

--- a/lib/kredis/types/slots.rb
+++ b/lib/kredis/types/slots.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Kredis::Types::Slots < Kredis::Types::Proxying
   class NotAvailable < StandardError; end
 

--- a/lib/kredis/types/unique_list.rb
+++ b/lib/kredis/types/unique_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # You'd normally call this a set, but Redis already has another data type for that
 class Kredis::Types::UniqueList < Kredis::Types::List
   proxying :multi, :ltrim, :exists?

--- a/lib/kredis/version.rb
+++ b/lib/kredis/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kredis
   VERSION = "1.5.0"
 end

--- a/lib/tasks/kredis/install.rake
+++ b/lib/tasks/kredis/install.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :kredis do
   desc "Install kredis"
   task :install do

--- a/test/attributes_callbacks_test.rb
+++ b/test/attributes_callbacks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class AttributesCallbacksTest < ActiveSupport::TestCase

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "active_support/core_ext/integer"
 
@@ -249,7 +251,7 @@ class AttributesTest < ActiveSupport::TestCase
     assert @person.onboarded.value
 
     @person.onboarded.value = false
-    refute @person.onboarded.value
+    assert_not @person.onboarded.value
   end
 
   test "missing id to constrain key" do

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class CallbacksTest < ActiveSupport::TestCase
@@ -30,7 +32,7 @@ class CallbacksTest < ActiveSupport::TestCase
     attention = Kredis.slot "attention", after_change: ->(slot) { @callback_check = slot.available? }
     attention.reserve
 
-    refute @callback_check
+    assert_not @callback_check
   end
 
   test "enum with after_change proc callback" do

--- a/test/connections_test.rb
+++ b/test/connections_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ConnectionsTest < ActiveSupport::TestCase

--- a/test/log_subscriber_test.rb
+++ b/test/log_subscriber_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "active_support/log_subscriber/test_helper"
 

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class MigrationTest < ActiveSupport::TestCase

--- a/test/namespace_test.rb
+++ b/test/namespace_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class NamespaceTest < ActiveSupport::TestCase

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ProxyTest < ActiveSupport::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 require "active_support/test_case"
 require "active_support/testing/autorun"

--- a/test/types/counter_test.rb
+++ b/test/types/counter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "active_support/core_ext/integer"
 

--- a/test/types/cycle_test.rb
+++ b/test/types/cycle_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "active_support/core_ext/integer"
 

--- a/test/types/enum_test.rb
+++ b/test/types/enum_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class EnumTest < ActiveSupport::TestCase

--- a/test/types/flag_test.rb
+++ b/test/types/flag_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class FlagTest < ActiveSupport::TestCase

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "active_support/core_ext/integer"
 
@@ -87,7 +89,7 @@ class HashTest < ActiveSupport::TestCase
   test "exists?" do
     assert_not @hash.exists?
 
-    @hash[:key]  = :value
+    @hash[:key] = :value
     assert @hash.exists?
   end
 end

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "active_support/core_ext/integer"
 

--- a/test/types/ordered_set_test.rb
+++ b/test/types/ordered_set_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class OrderedSetTest < ActiveSupport::TestCase

--- a/test/types/scalar_test.rb
+++ b/test/types/scalar_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "active_support/core_ext/integer"
 
@@ -32,9 +34,9 @@ class ScalarTest < ActiveSupport::TestCase
     assert_equal true, boolean.value
     boolean.value = false
     assert_equal false, boolean.value
-    boolean.value = 't'
+    boolean.value = "t"
     assert_equal true, boolean.value
-    boolean.value = 'false'
+    boolean.value = "false"
     assert_equal false, boolean.value
   end
 
@@ -61,8 +63,8 @@ class ScalarTest < ActiveSupport::TestCase
     json.value = { "one" => 1, "string" => "hello" }
     assert_equal({ "one" => 1, "string" => "hello" }, json.value)
 
-    json.value = {"json_class"=>"String", "raw"=>[97, 98, 99]}
-    assert_equal({"json_class"=>"String", "raw"=>[97, 98, 99]}, json.value)
+    json.value = { "json_class" => "String", "raw" => [97, 98, 99] }
+    assert_equal({ "json_class" => "String", "raw" => [97, 98, 99] }, json.value)
   end
 
   test "invalid type" do
@@ -144,7 +146,7 @@ class ScalarTest < ActiveSupport::TestCase
 
   test "all scalar types can be configured with expires_in" do
     duration = 1.second
-    scalar = Kredis.scalar("ephemeral", expires_in: duration)
+    Kredis.scalar("ephemeral", expires_in: duration)
 
     scalar = Kredis.string("ephemeral", expires_in: duration)
     assert_equal duration, scalar.expires_in

--- a/test/types/set_test.rb
+++ b/test/types/set_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "active_support/core_ext/object/inclusion"
 

--- a/test/types/slots_test.rb
+++ b/test/types/slots_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SlotsTest < ActiveSupport::TestCase

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UniqueListTest < ActiveSupport::TestCase


### PR DESCRIPTION
Brings in RuboCop with the same configuration (and gem dependencies) as https://github.com/rails/rails

Also adds a CI step to lint PRs, again as per https://github.com/rails/rails.

There are 76 offences currently, I can address those in a subsequent PR.