### PR TITLE
Support line filtering in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "active_support/test_case"
 require "active_support/testing/autorun"
+require "rails/test_unit/line_filtering"
 require "minitest/mock"
 require "byebug"
 
@@ -11,6 +12,8 @@ Kredis.configurator = Class.new { def config_for(name) { db: "1" } end }.new
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 
 class ActiveSupport::TestCase
+  extend Rails::LineFiltering
+
   teardown { Kredis.clear_all }
 
   class RedisUnavailableProxy


### PR DESCRIPTION
Line filtering was not working when running tests with `bin/test`.

e.g. `bin/test test/attributes_test.rb:82` would run all tests, not only the one defined on line 82.

This is because `rails/plugin/test` does not support line filtering. We should probably fix that upstream.

I opened https://github.com/rails/rails/issues/48696 to track that.