### PR TITLE
Make Boolean storage more efficient

### DIFF
--- a/lib/kredis/type/boolean.rb
+++ b/lib/kredis/type/boolean.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Kredis
+  module Type
+    class Boolean < ActiveModel::Type::Boolean
+      def serialize(value)
+        super ? 1 : 0
+      end
+    end
+  end
+end

--- a/lib/kredis/type_casting.rb
+++ b/lib/kredis/type_casting.rb
@@ -1,7 +1,8 @@
 require "json"
 require "active_model/type"
-require "kredis/type/json"
+require "kredis/type/boolean"
 require "kredis/type/datetime"
+require "kredis/type/json"
 
 module Kredis::TypeCasting
   class InvalidType < StandardError; end
@@ -11,7 +12,7 @@ module Kredis::TypeCasting
     integer: ActiveModel::Type::Integer.new,
     decimal: ActiveModel::Type::Decimal.new,
     float: ActiveModel::Type::Float.new,
-    boolean: ActiveModel::Type::Boolean.new,
+    boolean: Kredis::Type::Boolean.new,
     datetime: Kredis::Type::DateTime.new,
     json: Kredis::Type::Json.new
   }

--- a/test/types/flag_test.rb
+++ b/test/types/flag_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "active_support/core_ext/integer"
 
 class FlagTest < ActiveSupport::TestCase
   setup { @flag = Kredis.flag "myflag" }

--- a/test/types/scalar_test.rb
+++ b/test/types/scalar_test.rb
@@ -38,6 +38,22 @@ class ScalarTest < ActiveSupport::TestCase
     assert_equal false, boolean.value
   end
 
+  test "boolean casting" do
+    boolean = Kredis.boolean "myscalar"
+
+    boolean.value = true
+    assert_equal "1", boolean.get
+
+    boolean.value = false
+    assert_equal "0", boolean.get
+
+    boolean.set "true"
+    assert_equal true, boolean.value
+
+    boolean.set "false"
+    assert_equal false, boolean.value
+  end
+
   test "datetime" do
     datetime = Kredis.datetime "myscalar"
     datetime.value = 5.days.from_now.midnight


### PR DESCRIPTION
Closes https://github.com/rails/kredis/issues/116

Rather than store the boolean as a string, store it as a 1 or 0. This is more efficient in terms of storage.

This change is backwards-compatible, so existing boolean values will continue to work as expected.

cc @roharon