### PR TITLE
Adds include? to ordered set

### DIFF
--- a/lib/kredis/types/ordered_set.rb
+++ b/lib/kredis/types/ordered_set.rb
@@ -3,7 +3,7 @@
 class Kredis::Types::OrderedSet < Kredis::Types::Proxying
   prepend Kredis::DefaultValues
 
-  proxying :multi, :zrange, :zrem, :zadd, :zremrangebyrank, :zcard, :exists?, :del, :zrank
+  proxying :multi, :zrange, :zrem, :zadd, :zremrangebyrank, :zcard, :exists?, :del, :zscore
 
   attr_accessor :typed
   attr_reader :limit

--- a/lib/kredis/types/ordered_set.rb
+++ b/lib/kredis/types/ordered_set.rb
@@ -3,7 +3,7 @@
 class Kredis::Types::OrderedSet < Kredis::Types::Proxying
   prepend Kredis::DefaultValues
 
-  proxying :multi, :zrange, :zrem, :zadd, :zremrangebyrank, :zcard, :exists?, :del
+  proxying :multi, :zrange, :zrem, :zadd, :zremrangebyrank, :zcard, :exists?, :del, :zrank
 
   attr_accessor :typed
   attr_reader :limit
@@ -15,6 +15,10 @@ class Kredis::Types::OrderedSet < Kredis::Types::Proxying
 
   def remove(*elements)
     zrem(types_to_strings(elements, typed))
+  end
+
+  def include?(*elements)
+    zrank(type_to_string(elements, typed)).present?
   end
 
   def prepend(elements)

--- a/lib/kredis/types/ordered_set.rb
+++ b/lib/kredis/types/ordered_set.rb
@@ -18,7 +18,7 @@ class Kredis::Types::OrderedSet < Kredis::Types::Proxying
   end
 
   def include?(element)
-    zrank(type_to_string(element, typed)).present?
+    !!zscore(type_to_string(element, typed))
   end
 
   def prepend(elements)

--- a/lib/kredis/types/ordered_set.rb
+++ b/lib/kredis/types/ordered_set.rb
@@ -17,8 +17,8 @@ class Kredis::Types::OrderedSet < Kredis::Types::Proxying
     zrem(types_to_strings(elements, typed))
   end
 
-  def include?(*elements)
-    zrank(type_to_string(elements, typed)).present?
+  def include?(element)
+    zrank(type_to_string(element, typed)).present?
   end
 
   def prepend(elements)

--- a/test/types/ordered_set_test.rb
+++ b/test/types/ordered_set_test.rb
@@ -72,8 +72,6 @@ class OrderedSetTest < ActiveSupport::TestCase
   end
 
   test "include?" do
-    assert_not @set.include? 4
-
     @set.append(%w[ 1 2 3 4 5 ])
 
     assert @set.include?(1)

--- a/test/types/ordered_set_test.rb
+++ b/test/types/ordered_set_test.rb
@@ -76,8 +76,8 @@ class OrderedSetTest < ActiveSupport::TestCase
 
     @set.append(%w[ 1 2 3 4 5 ])
 
-    assert @set.include?(1, 4)
-    assert_not @set.include?(3, 6)
+    assert @set.include?(1)
+    assert_not @set.include?(6)
   end
 
   test "appending over limit" do

--- a/test/types/ordered_set_test.rb
+++ b/test/types/ordered_set_test.rb
@@ -71,6 +71,15 @@ class OrderedSetTest < ActiveSupport::TestCase
     assert @set.exists?
   end
 
+  test "include?" do
+    assert_not @set.include? 4
+
+    @set.append(%w[ 1 2 3 4 5 ])
+
+    assert @set.include?(1, 4)
+    assert_not @set.include?(3, 6)
+  end
+
   test "appending over limit" do
     @set.append(%w[ 1 2 3 4 5 ])
     @set.append(%w[ 6 7 8 ])


### PR DESCRIPTION
Given that ordered set is using the underlying Redis sorted set, I believe it can be usefull to have the 'include?' function also there to check if an element or number of elements are already there by using Redis zrank.