### PR TITLE
Remove unnecessary Redis command for Counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ A development console is available by running `bin/console`.
 
 From there, you can experiment with Kredis. e.g.
 
-```rb
+```erb
 >> str = Kredis.string "mystring"
   Kredis  (0.1ms)  Connected to shared
 =>

--- a/lib/kredis/types/counter.rb
+++ b/lib/kredis/types/counter.rb
@@ -9,14 +9,14 @@ class Kredis::Types::Counter < Kredis::Types::Proxying
 
   def increment(by: 1)
     multi do
-      set 0, ex: expires_in, nx: true
+      set 0, ex: expires_in, nx: true if expires_in
       incrby by
     end[-1]
   end
 
   def decrement(by: 1)
     multi do
-      set 0, ex: expires_in, nx: true
+      set 0, ex: expires_in, nx: true if expires_in
       decrby by
     end[-1]
   end


### PR DESCRIPTION
Performance improvement for Counter type.

Don't send extra set command, if there is no expire for key.

Also fixed rubocop README check broken by [rails commit](https://github.com/rails/rails/commit/a7ee313d91db21dbadb313a74a7267c8046304be)