### PR TITLE
Fix rubocop warnings

### DIFF
--- a/lib/kredis/version.rb
+++ b/lib/kredis/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kredis
   VERSION = "1.6.0"
 end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -160,7 +160,7 @@ class AttributesTest < ActiveSupport::TestCase
     assert_not @person.special?
 
     @person.special.mark
-    assert @person.special?
+    assert_predicate @person, :special?
 
     @person.special.remove
     assert_not @person.special?
@@ -170,7 +170,7 @@ class AttributesTest < ActiveSupport::TestCase
     assert_not @person.address.assigned?
 
     @person.address.value = "Copenhagen"
-    assert @person.address.assigned?
+    assert_predicate @person.address, :assigned?
     assert_equal "Copenhagen", @person.address.to_s
 
     @person.address.clear
@@ -234,7 +234,7 @@ class AttributesTest < ActiveSupport::TestCase
     assert_not @person.attention.reserve
 
     @person.attention.release
-    assert @person.attention.available?
+    assert_predicate @person.attention, :available?
 
     used_attention = false
 
@@ -251,7 +251,7 @@ class AttributesTest < ActiveSupport::TestCase
 
   test "slots" do
     assert @person.meetings.reserve
-    assert @person.meetings.available?
+    assert_predicate @person.meetings, :available?
 
     assert @person.meetings.reserve
     assert @person.meetings.reserve
@@ -259,7 +259,7 @@ class AttributesTest < ActiveSupport::TestCase
     assert_not @person.meetings.reserve
 
     @person.meetings.release
-    assert @person.meetings.available?
+    assert_predicate @person.meetings, :available?
 
     used_meeting = false
 
@@ -276,22 +276,22 @@ class AttributesTest < ActiveSupport::TestCase
   end
 
   test "enum" do
-    assert @person.morning.bright?
+    assert_predicate @person.morning, :bright?
 
     assert @person.morning.value = "blue"
-    assert @person.morning.blue?
+    assert_predicate @person.morning, :blue?
 
     assert_not @person.morning.black?
 
     assert @person.morning.value = "nonsense"
-    assert @person.morning.blue?
+    assert_predicate @person.morning, :blue?
 
     @person.morning.reset
-    assert @person.morning.bright?
+    assert_predicate @person.morning, :bright?
   end
 
   test "enum with default proc value" do
-    assert @person.eye_color_with_default_via_lambda.hazel?
+    assert_predicate @person.eye_color_with_default_via_lambda, :hazel?
   end
 
 

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -22,7 +22,7 @@ class MigrationTest < ActiveSupport::TestCase
 
     Kredis::Migration.migrate from: "old_proxy", to: @proxy.key
     assert_equal "hello there", @proxy.value
-    assert old_proxy.assigned?, "just copying the data"
+    assert_predicate old_proxy, :assigned?, "just copying the data"
   end
 
   test "migrate with blank keys" do

--- a/test/types/counter_test.rb
+++ b/test/types/counter_test.rb
@@ -78,7 +78,7 @@ class CounterTest < ActiveSupport::TestCase
     assert_not @counter.exists?
 
     @counter.increment
-    assert @counter.exists?
+    assert_predicate @counter, :exists?
   end
 
   test "default value" do

--- a/test/types/enum_test.rb
+++ b/test/types/enum_test.rb
@@ -26,32 +26,32 @@ class EnumTest < ActiveSupport::TestCase
   end
 
   test "predicates" do
-    assert @enum.one?
+    assert_predicate @enum, :one?
 
     @enum.value = "two"
-    assert @enum.two?
+    assert_predicate @enum, :two?
 
     assert_not @enum.three?
 
     @enum.three!
-    assert @enum.three?
+    assert_predicate @enum, :three?
 
     assert_not @enum.two?
   end
 
   test "validated value" do
-    assert @enum.one?
+    assert_predicate @enum, :one?
 
     @enum.value = "nonesense"
-    assert @enum.one?
+    assert_predicate @enum, :one?
   end
 
   test "reset" do
     @enum.value = "two"
-    assert @enum.two?
+    assert_predicate @enum, :two?
 
     @enum.reset
-    assert @enum.one?
+    assert_predicate @enum, :one?
   end
 
   test "exists?" do
@@ -59,6 +59,6 @@ class EnumTest < ActiveSupport::TestCase
     assert_not enum.exists?
 
     enum.value = "one"
-    assert enum.exists?
+    assert_predicate enum, :exists?
   end
 end

--- a/test/types/flag_test.rb
+++ b/test/types/flag_test.rb
@@ -10,7 +10,7 @@ class FlagTest < ActiveSupport::TestCase
     assert_not @flag.marked?
 
     @flag.mark
-    assert @flag.marked?
+    assert_predicate @flag, :marked?
 
     @flag.remove
     assert_not @flag.marked?
@@ -18,10 +18,10 @@ class FlagTest < ActiveSupport::TestCase
 
   test "expiring mark" do
     @flag.mark(expires_in: 1.second)
-    assert @flag.marked?
+    assert_predicate @flag, :marked?
 
     sleep 0.5.seconds
-    assert @flag.marked?
+    assert_predicate @flag, :marked?
 
     sleep 0.6.seconds
     assert_not @flag.marked?
@@ -33,10 +33,10 @@ class FlagTest < ActiveSupport::TestCase
     assert @flag.mark(expires_in: 1.second, force: true)
     assert_not @flag.mark(expires_in: 10.seconds, force: false)
 
-    assert @flag.marked?
+    assert_predicate @flag, :marked?
 
     sleep 0.5.seconds
-    assert @flag.marked?
+    assert_predicate @flag, :marked?
 
     sleep 0.6.seconds
     assert_not @flag.marked?

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -90,7 +90,7 @@ class HashTest < ActiveSupport::TestCase
     assert_not @hash.exists?
 
     @hash[:key] = :value
-    assert @hash.exists?
+    assert_predicate @hash, :exists?
   end
 
   test "default value" do

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -67,7 +67,7 @@ class ListTest < ActiveSupport::TestCase
     assert_not @list.exists?
 
     @list.append(%w[ 1 2 3 ])
-    assert @list.exists?
+    assert_predicate @list, :exists?
   end
 
   test "ltrim" do

--- a/test/types/ordered_set_test.rb
+++ b/test/types/ordered_set_test.rb
@@ -68,7 +68,7 @@ class OrderedSetTest < ActiveSupport::TestCase
     assert_not @set.exists?
 
     @set.append [ 1, 2 ]
-    assert @set.exists?
+    assert_predicate @set, :exists?
   end
 
   test "include?" do

--- a/test/types/scalar_test.rb
+++ b/test/types/scalar_test.rb
@@ -95,7 +95,7 @@ class ScalarTest < ActiveSupport::TestCase
     assert_not string.assigned?
 
     string.value = "Something!"
-    assert string.assigned?
+    assert_predicate string, :assigned?
   end
 
   test "clear" do

--- a/test/types/set_test.rb
+++ b/test/types/set_test.rb
@@ -90,7 +90,7 @@ class SetTest < ActiveSupport::TestCase
     assert_not @set.exists?
 
     @set.add(%w[ 1 2 3 ])
-    assert @set.exists?
+    assert_predicate @set, :exists?
   end
 
   test "srandmember" do

--- a/test/types/slots_test.rb
+++ b/test/types/slots_test.rb
@@ -7,10 +7,10 @@ class SlotsTest < ActiveSupport::TestCase
 
   test "reserve until no availability" do
     assert @slots.reserve
-    assert @slots.available?
+    assert_predicate @slots, :available?
 
     assert @slots.reserve
-    assert @slots.available?
+    assert_predicate @slots, :available?
 
     assert @slots.reserve
     assert_not @slots.available?
@@ -25,7 +25,7 @@ class SlotsTest < ActiveSupport::TestCase
     assert_not @slots.available?
 
     @slots.release
-    assert @slots.available?
+    assert_predicate @slots, :available?
   end
 
   test "release when slots are reserved" do
@@ -53,7 +53,7 @@ class SlotsTest < ActiveSupport::TestCase
       false # ensure that block return value isn't returned from #reserve
     })
 
-    assert @slots.available?
+    assert_predicate @slots, :available?
   end
 
   test "failed reserve with block" do
@@ -115,6 +115,6 @@ class SlotsTest < ActiveSupport::TestCase
     assert_not @slots.exists?
 
     @slots.reserve
-    assert @slots.exists?
+    assert_predicate @slots, :exists?
   end
 end

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -51,7 +51,7 @@ class UniqueListTest < ActiveSupport::TestCase
     assert_not @list.exists?
 
     @list.append [ 1, 2 ]
-    assert @list.exists?
+    assert_predicate @list, :exists?
   end
 
   test "appending over limit" do


### PR DESCRIPTION
I recently made a comment urging the release of kredis.
Thank you for releasing 1.6.0.
I don't know if this is a result of that, but I noticed that the tests in the main branch are red.
Fortunately, I ran Rubocop locally and all errors were resolved.
I don't know if this qualifies as an open source contribution, but let me submit it as a PR.

Here is my output:

```
$ bundle exec rubocop
Inspecting 56 files
........................................................

56 files inspected, no offenses detected
```