### PR TITLE
Support expiration time for lists

### DIFF
--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -61,8 +61,8 @@ module Kredis::Types
     type_from(Hash, config, key, after_change: after_change, default: default, typed: typed)
   end
 
-  def list(key, default: nil, typed: :string, config: :shared, after_change: nil)
-    type_from(List, config, key, after_change: after_change, default: default, typed: typed)
+  def list(key, default: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+    type_from(List, config, key, after_change: after_change, default: default, typed: typed, expires_in: expires_in)
   end
 
   def unique_list(key, default: nil, typed: :string, limit: nil, config: :shared, after_change: nil)

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -20,7 +20,7 @@ class Kredis::Types::List < Kredis::Types::Proxying
     return if elements.flatten.empty?
 
     lpush types_to_strings(elements, typed)
-    expire_in expires_in if expires_in.present?
+    expire_in expires_in if expires_in
     elements
   end
 
@@ -28,7 +28,7 @@ class Kredis::Types::List < Kredis::Types::Proxying
     return if elements.flatten.empty?
 
     rpush types_to_strings(elements, typed)
-    expire_in expires_in if expires_in.present?
+    expire_in expires_in if expires_in
     elements
   end
   alias << append

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -20,7 +20,7 @@ class Kredis::Types::List < Kredis::Types::Proxying
     return if elements.flatten.empty?
 
     lpush types_to_strings(elements, typed)
-    expire_in expires_in if expires_in
+    expire expires_in.to_i, nx: true if expires_in
     elements
   end
 
@@ -28,7 +28,7 @@ class Kredis::Types::List < Kredis::Types::Proxying
     return if elements.flatten.empty?
 
     rpush types_to_strings(elements, typed)
-    expire_in expires_in if expires_in
+    expire expires_in.to_i, nx: true if expires_in
     elements
   end
   alias << append
@@ -39,10 +39,6 @@ class Kredis::Types::List < Kredis::Types::Proxying
 
   def last(n = nil)
     n ? lrange(-n, -1) : lrange(-1, -1).first
-  end
-
-  def expire_in(seconds)
-    expire seconds.to_i
   end
 
   private

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -78,9 +78,12 @@ class ListTest < ActiveSupport::TestCase
 
   test "append with expiring list" do
     @list = Kredis.list "mylist", expires_in: 1.second
-    @list.append(%w[1 2 3])
-
-    sleep 0.5.seconds
+    @list.append(%w[1 2])
+    
+    sleep 0.2.seconds
+    @list.append(3)
+    
+    sleep 0.3.seconds
     assert_equal %w[ 1 2 3 ], @list.elements
 
     sleep 0.6.seconds
@@ -89,9 +92,12 @@ class ListTest < ActiveSupport::TestCase
 
   test "prepend with expiring list" do
     @list = Kredis.list "mylist", expires_in: 1.second
-    @list.prepend(%w[1 2 3])
+    @list.prepend(%w[1 2])
 
-    sleep 0.5.seconds
+    sleep 0.2.seconds
+    @list.prepend(3)
+
+    sleep 0.3.seconds
     assert_equal %w[ 3 2 1 ], @list.elements
 
     sleep 0.6.seconds

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -76,6 +76,27 @@ class ListTest < ActiveSupport::TestCase
     assert_equal %w[ 2 3 ], @list.elements
   end
 
+  test "append with expiring list" do
+    @list = Kredis.list "mylist", expires_in: 1.second
+    @list.append(%w[1 2 3])
+
+    sleep 0.5.seconds
+    assert_equal %w[ 1 2 3 ], @list.elements
+
+    sleep 0.6.seconds
+    assert_equal [], @list.elements
+  end
+
+  test "prepend with expiring list" do
+    @list = Kredis.list "mylist", expires_in: 1.second
+    @list.prepend(%w[1 2 3])
+
+    sleep 0.5.seconds
+    assert_equal %w[ 3 2 1 ], @list.elements
+
+    sleep 0.6.seconds
+    assert_equal [], @list.elements
+  end
 
   test "default" do
     @list = Kredis.list "mylist", default: %w[ 1 2 3 ]


### PR DESCRIPTION
Closes #129 

Since Leon did not respond, I created a PR on his behalf.
I tried to find another way to do it, but there is little change from the code he first wrote.
One thing to note is that the array seemed to be empty if I specified the values for expires_in and default at the same time.

```ruby
  test "append with default expiring list" do
    @list = Kredis.list "mylist", default: ->() { %w[ 1 ] }, expires_in: 1.second
    @list.append(%w[ 2 3 ])

    sleep 0.5.seconds
    assert_equal %w[ 1 2 3 ], @list.elements

    sleep 0.6.seconds
    assert_equal [], @list.elements # <== It should be ["1"] but I don't figure out to set default here..
  end
```

If this PR is accepted, I will look into other Hash, OrderedSet, etc. to see if they can support expires_in as well.