### PR TITLE
Use a default config if shared.yml isn't available

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Additional configurations can be added under `config/redis/*.yml` and referenced
 
 Kredis passes the configuration to `Redis.new` to establish the connection. See the [Redis documentation](https://github.com/redis/redis-rb) for other configuration options.
 
+If you don't have config/redis/shared.yml (or use another named configuration), Kredis will default to look in env for `REDIS_URL`, then fallback to a default URL of `redis://127.0.0.1:6379/0`.
+
 ### Redis support
 
 Kredis works with Redis server 4.0+, with the [Redis Ruby](https://github.com/redis/redis-rb) client version 4.2+.

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Additional configurations can be added under `config/redis/*.yml` and referenced
 
 Kredis passes the configuration to `Redis.new` to establish the connection. See the [Redis documentation](https://github.com/redis/redis-rb) for other configuration options.
 
-If you don't have config/redis/shared.yml (or use another named configuration), Kredis will default to look in env for `REDIS_URL`, then fallback to a default URL of `redis://127.0.0.1:6379/0`.
+If you don't have `config/redis/shared.yml` (or use another named configuration), Kredis will default to look in env for `REDIS_URL`, then fallback to a default URL of `redis://127.0.0.1:6379/0`.
 
 ### Redis support
 

--- a/lib/kredis/connections.rb
+++ b/lib/kredis/connections.rb
@@ -14,8 +14,10 @@ module Kredis::Connections
     connections[name] ||= Kredis.instrument :meta, message: "Connected to #{name}" do
       if configurator.root.join("config/redis/#{name}.yml").exist?
         connector.call configurator.config_for("redis/#{name}")
-      else
+      elsif name == :shared
         Redis.new url: ENV.fetch("REDIS_URL", DEFAULT_REDIS_URL), timeout: DEFAULT_REDIS_TIMEOUT
+      else
+        raise "No configuration found for #{name}"
       end
     end
   end

--- a/lib/kredis/connections.rb
+++ b/lib/kredis/connections.rb
@@ -13,7 +13,7 @@ module Kredis::Connections
   def configured_for(name)
     connections[name] ||= Kredis.instrument :meta, message: "Connected to #{name}" do
       if configurator.root.join("config/redis/#{name}.yml").exist?
-        redis = connector.call configurator.config_for("redis/#{name}")
+        connector.call configurator.config_for("redis/#{name}")
       else
         Redis.new url: ENV.fetch("REDIS_URL", DEFAULT_REDIS_URL), timeout: DEFAULT_REDIS_TIMEOUT
       end

--- a/lib/kredis/connections.rb
+++ b/lib/kredis/connections.rb
@@ -3,13 +3,20 @@
 require "redis"
 
 module Kredis::Connections
+  DEFAULT_REDIS_URL     = "redis://127.0.0.1:6379/0"
+  DEFAULT_REDIS_TIMEOUT = 1
+
   mattr_accessor :connections, default: Hash.new
   mattr_accessor :configurator
   mattr_accessor :connector, default: ->(config) { Redis.new(config) }
 
   def configured_for(name)
     connections[name] ||= Kredis.instrument :meta, message: "Connected to #{name}" do
-      connector.call configurator.config_for("redis/#{name}")
+      if configurator.root.join("config/redis/#{name}.yml").exist?
+        redis = connector.call configurator.config_for("redis/#{name}")
+      else
+        Redis.new url: ENV.fetch("REDIS_URL", DEFAULT_REDIS_URL), timeout: DEFAULT_REDIS_TIMEOUT
+      end
     end
   end
 

--- a/test/connections_test.rb
+++ b/test/connections_test.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "yaml"
 
 class ConnectionsTest < ActiveSupport::TestCase
+  setup { Kredis.connections = {} }
   teardown { Kredis.namespace = nil }
 
   test "clear all" do
@@ -25,5 +27,26 @@ class ConnectionsTest < ActiveSupport::TestCase
 
     assert_nil integer.value
     assert_equal "don't remove me", Kredis.configured_for(:shared).get("mykey")
+  end
+
+  test "config from file" do
+    fixture_config = YAML.load_file(Pathname.new(Dir.pwd).join("test/fixtures/config/redis/shared.yml"))["test"].symbolize_keys
+
+    Kredis.configurator.stub(:config_for, fixture_config) do
+      Kredis.configurator.stub(:root, Pathname.new(Dir.pwd).join("test/fixtures")) do
+        assert_match %r|redis://127.0.0.1:6379/4|, Kredis.redis.inspect
+      end
+    end
+  end
+
+  test "default config in env" do
+    ENV["REDIS_URL"] = "redis://127.0.0.1:6379/3"
+    assert_match %r|redis://127.0.0.1:6379/3|, Kredis.redis.inspect
+  ensure
+    ENV.delete("REDIS_URL")
+  end
+
+  test "default config without env" do
+    assert_match %r|redis://127.0.0.1:6379/0|, Kredis.redis.inspect
   end
 end

--- a/test/connections_test.rb
+++ b/test/connections_test.rb
@@ -49,4 +49,10 @@ class ConnectionsTest < ActiveSupport::TestCase
   test "default config without env" do
     assert_match %r|redis://127.0.0.1:6379/0|, Kredis.redis.inspect
   end
+
+  test "custom config is missing" do
+    assert_raises do
+      Kredis.configured_for(:missing).set "mykey", "won't get set"
+    end
+  end
 end

--- a/test/fixtures/config/redis/shared.yml
+++ b/test/fixtures/config/redis/shared.yml
@@ -1,0 +1,3 @@
+test:
+  url: redis://127.0.0.1:6379/4
+  timeout: 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,10 @@ require "debug"
 
 require "kredis"
 
-Kredis.configurator = Class.new { def config_for(name) { db: "1" } end }.new
+Kredis.configurator = Class.new do
+  def config_for(name) { db: "1" } end
+  def root() Pathname.new(".") end
+end.new
 
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 


### PR DESCRIPTION
We don't actually need a config in most basic cases. We can just connect to what's in REDIS_URL or a default of `redis://127.0.0.1:6379/0`.