### PR TITLE
Add limiter type

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,20 @@ sleep 0.5.seconds
 true == flag.marked?            #=> EXISTS myflag
 sleep 0.6.seconds
 false == flag.marked?           #=> EXISTS myflag
+
+limiter = Kredis.limiter "mylimit", limit: 3, expires_in: 5.seconds
+0 == limiter.value              # => GET "limiter"
+limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
+limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
+limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
+false == limiter.exceeded?      # => GET "limiter"
+limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
+true == limiter.exceeded?       # => GET "limiter"
+sleep 6
+limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
+limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
+limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
+false == limiter.exceeded?      # => GET "limiter"
 ```
 
 ### Models

--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -72,6 +72,10 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, default: default, config: config, after_change: after_change, expires_in: expires_in
     end
 
+    def kredis_limiter(name, limit:, key: nil, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, limit: limit, config: config, after_change: after_change, expires_in: expires_in
+    end
+
     def kredis_hash(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil)
       kredis_connection_with __method__, name, key, default: default, typed: typed, config: config, after_change: after_change
     end

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -85,6 +85,10 @@ module Kredis::Types
     type_from(Slots, config, key, after_change: after_change, available: available)
   end
 
+  def limiter(key, limit:, expires_in: nil, config: :shared, after_change: nil)
+    type_from(Limiter, config, key, after_change: after_change, expires_in: expires_in, limit: limit)
+  end
+
   private
     def type_from(type_klass, config, key, after_change: nil, **options)
       type_klass.new(configured_for(config), namespaced_key(key), **options).then do |type|
@@ -107,3 +111,4 @@ require "kredis/types/unique_list"
 require "kredis/types/set"
 require "kredis/types/ordered_set"
 require "kredis/types/slots"
+require "kredis/types/limiter"

--- a/lib/kredis/types/limiter.rb
+++ b/lib/kredis/types/limiter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# A limiter is a specialized form of a counter that can be checked whether it has been exceeded and is provided fail safe. This means it can be used to guard login screens from brute force attacks without denying access in case Redis is offline.
+#
+# It will usually be used as an expiring limiter. Note that the limiter expires in total after the `expires_in` time used upon the first poke.
+#
+# It offers no guarentee that you can't poke yourself above the limit. You're responsible for checking `#exceeded?` yourself first, and this may produce a race condition. So only use this when the exact number of pokes is not critical.
+class Kredis::Types::Limiter < Kredis::Types::Counter
+  class LimitExceeded < StandardError; end
+
+  attr_accessor :limit
+
+  def poke
+    failsafe returning: true do
+      increment
+    end
+  end
+
+  def exceeded?
+    failsafe returning: false do
+      value >= limit
+    end
+  end
+end

--- a/test/types/limiter_test.rb
+++ b/test/types/limiter_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LimiterTest < ActiveSupport::TestCase
+  setup { @limiter = Kredis.limiter "mylimit", limit: 5 }
+
+  test "exceeded after limit is reached" do
+    4.times do
+      @limiter.poke
+      assert_not @limiter.exceeded?
+    end
+
+    @limiter.poke
+    assert @limiter.exceeded?
+  end
+
+  test "never exceeded when redis is down" do
+    stub_redis_down(@limiter) do
+      10.times do
+        @limiter.poke
+        assert_not @limiter.exceeded?
+      end
+    end
+  end
+end


### PR DESCRIPTION
A limiter is a specialized form of a counter that can be checked whether it has been exceeded and is provided fail safe. This means it can be used to guard login screens from brute force attacks without denying access in case Redis is offline.

It will usually be used as an expiring limiter. Note that the limiter expires in total after the `expires_in` time used upon the first poke.

It offers no guarentee that you can't poke yourself above the limit. You're responsible for checking `#exceeded?` yourself first, and this may produce a race condition. So only use this when the exact number of pokes is not critical.

```
limiter = Kredis.limiter "mylimit", limit: 3, expires_in: 5.seconds
0 == limiter.value              # => GET "limiter"
limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
false == limiter.exceeded?      # => GET "limiter"
limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
true == limiter.exceeded?       # => GET "limiter"
sleep 6
limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
false == limiter.exceeded?      # => GET "limiter"
```