### PR TITLE
Redundant limiter.poke in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ limiter = Kredis.limiter "mylimit", limit: 3, expires_in: 5.seconds
 0 == limiter.value              # => GET "limiter"
 limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
 limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
-limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
 false == limiter.exceeded?      # => GET "limiter"
 limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
 true == limiter.exceeded?       # => GET "limiter"

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ true == limiter.exceeded?       # => GET "limiter"
 sleep 6
 limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
 limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
-limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
 false == limiter.exceeded?      # => GET "limiter"
 ```
 


### PR DESCRIPTION
```ruby
limiter = Kredis.limiter "mylimit", limit: 3, expires_in: 5.seconds
7.times { pp [limiter.poke, limiter.exceeded?] }
[1, false]
[2, false]
[3, true]
[4, true]
[5, true]
[6, true]
[7, true]
```