### PR TITLE
Support `expires_in` for `List`, `Set`, `UniqueList`, `OrderedSet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
 false == limiter.exceeded?      # => GET "limiter"
 ```
 
+Lists, unique lists, sets, and ordered sets support expiration:
+
+```ruby
+set = Kredis.set "myset", expires_in: 1.second
+set.add "hello", "world" # => SADD myset "hello" "world"
+true == set.include?("hello") # => SISMEMBER myset "hello
+sleep 2
+[] == set.members # => SMEMBERS myset
+```
+
+To support lower versions of redis, which does not has `nx` option on `EXPIRE` command, multiple commands are used to achieve the same effect.
+
 ### Models
 
 You can use all these structures in models:
@@ -193,6 +205,7 @@ class Person < ApplicationRecord
   kredis_unique_list :skills, limit: 2
   kredis_enum :morning, values: %w[ bright blue black ], default: "bright"
   kredis_counter :steps, expires_in: 1.hour
+  kredis_set :favorite_colors, expires_in: 1.day
 
   private
     def generate_names_key

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ limiter.poke                    # => SET limiter 0 NX + INCRBY limiter 1
 false == limiter.exceeded?      # => GET "limiter"
 ```
 
-Lists, unique lists, sets, and ordered sets support expiration:
+Lists, unique lists, sets, ordered sets, and hashes support expiration:
 
 ```ruby
 set = Kredis.set "myset", expires_in: 1.second

--- a/lib/kredis.rb
+++ b/lib/kredis.rb
@@ -11,6 +11,7 @@ require "kredis/log_subscriber"
 require "kredis/namespace"
 require "kredis/type_casting"
 require "kredis/default_values"
+require "kredis/expiration"
 require "kredis/types"
 require "kredis/attributes"
 

--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -44,20 +44,20 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, default: default, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_list(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, default: default, typed: typed, config: config, after_change: after_change
+    def kredis_list(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, default: default, typed: typed, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_unique_list(name, limit: nil, key: nil, default: nil, typed: :string, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, default: default, limit: limit, typed: typed, config: config, after_change: after_change
+    def kredis_unique_list(name, limit: nil, key: nil, default: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, default: default, limit: limit, typed: typed, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_set(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, default: default, typed: typed, config: config, after_change: after_change
+    def kredis_set(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, default: default, typed: typed, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_ordered_set(name, limit: nil, default: nil, key: nil, typed: :string, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, default: default, limit: limit, typed: typed, config: config, after_change: after_change
+    def kredis_ordered_set(name, limit: nil, default: nil, key: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, default: default, limit: limit, typed: typed, config: config, after_change: after_change, expires_in: expires_in
     end
 
     def kredis_slot(name, key: nil, config: :shared, after_change: nil)

--- a/lib/kredis/attributes.rb
+++ b/lib/kredis/attributes.rb
@@ -76,8 +76,8 @@ module Kredis::Attributes
       kredis_connection_with __method__, name, key, limit: limit, config: config, after_change: after_change, expires_in: expires_in
     end
 
-    def kredis_hash(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil)
-      kredis_connection_with __method__, name, key, default: default, typed: typed, config: config, after_change: after_change
+    def kredis_hash(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+      kredis_connection_with __method__, name, key, default: default, typed: typed, config: config, after_change: after_change, expires_in: expires_in
     end
 
     def kredis_boolean(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)

--- a/lib/kredis/expiration.rb
+++ b/lib/kredis/expiration.rb
@@ -9,9 +9,9 @@ module Kredis::Expiration
   end
 
   private
-    def with_expiration(&block)
+    def with_expiration(suppress: false, &block)
       result = block.call
-      if expires_in && ttl < 0
+      if !suppress && expires_in && ttl < 0
         expire expires_in.to_i
       end
       result

--- a/lib/kredis/expiration.rb
+++ b/lib/kredis/expiration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Kredis::Expiration
+  extend ActiveSupport::Concern
+
+  included do
+    proxying :ttl, :expire
+    attr_accessor :expires_in
+  end
+
+  private
+    def with_expiration(&block)
+      result = block.call
+      if expires_in && ttl < 0
+        expire expires_in.to_i
+      end
+      result
+    end
+end

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -69,8 +69,8 @@ module Kredis::Types
     type_from(UniqueList, config, key, after_change: after_change, default: default, typed: typed, limit: limit)
   end
 
-  def set(key, default: nil, typed: :string, config: :shared, after_change: nil)
-    type_from(Set, config, key, after_change: after_change, default: default, typed: typed)
+  def set(key, default: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+    type_from(Set, config, key, after_change: after_change, default: default, typed: typed, expires_in: expires_in)
   end
 
   def ordered_set(key, default: nil, typed: :string, limit: nil, config: :shared, after_change: nil)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -65,8 +65,8 @@ module Kredis::Types
     type_from(List, config, key, after_change: after_change, default: default, typed: typed, expires_in: expires_in)
   end
 
-  def unique_list(key, default: nil, typed: :string, limit: nil, config: :shared, after_change: nil)
-    type_from(UniqueList, config, key, after_change: after_change, default: default, typed: typed, limit: limit)
+  def unique_list(key, default: nil, typed: :string, limit: nil, config: :shared, after_change: nil, expires_in: nil)
+    type_from(UniqueList, config, key, after_change: after_change, default: default, typed: typed, limit: limit, expires_in: expires_in)
   end
 
   def set(key, default: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -73,8 +73,8 @@ module Kredis::Types
     type_from(Set, config, key, after_change: after_change, default: default, typed: typed, expires_in: expires_in)
   end
 
-  def ordered_set(key, default: nil, typed: :string, limit: nil, config: :shared, after_change: nil)
-    type_from(OrderedSet, config, key, after_change: after_change, default: default, typed: typed, limit: limit)
+  def ordered_set(key, default: nil, typed: :string, limit: nil, config: :shared, after_change: nil, expires_in: nil)
+    type_from(OrderedSet, config, key, after_change: after_change, default: default, typed: typed, limit: limit, expires_in: expires_in)
   end
 
   def slot(key, config: :shared, after_change: nil)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -61,8 +61,8 @@ module Kredis::Types
     type_from(Hash, config, key, after_change: after_change, default: default, typed: typed)
   end
 
-  def list(key, default: nil, typed: :string, config: :shared, after_change: nil)
-    type_from(List, config, key, after_change: after_change, default: default, typed: typed)
+  def list(key, default: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)
+    type_from(List, config, key, after_change: after_change, default: default, typed: typed, expires_in: expires_in)
   end
 
   def unique_list(key, default: nil, typed: :string, limit: nil, config: :shared, after_change: nil)

--- a/lib/kredis/types.rb
+++ b/lib/kredis/types.rb
@@ -57,8 +57,8 @@ module Kredis::Types
     type_from(Enum, config, key, after_change: after_change, values: values, default: default)
   end
 
-  def hash(key, typed: :string, default: nil, config: :shared, after_change: nil)
-    type_from(Hash, config, key, after_change: after_change, default: default, typed: typed)
+  def hash(key, typed: :string, default: nil, config: :shared, after_change: nil, expires_in: nil)
+    type_from(Hash, config, key, after_change: after_change, default: default, typed: typed, expires_in: expires_in)
   end
 
   def list(key, default: nil, typed: :string, config: :shared, after_change: nil, expires_in: nil)

--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -4,6 +4,7 @@ require "active_support/core_ext/hash"
 
 class Kredis::Types::Hash < Kredis::Types::Proxying
   prepend Kredis::DefaultValues
+  include Kredis::Expiration
 
   proxying :hget, :hset, :hmget, :hdel, :hgetall, :hkeys, :hvals, :del, :exists?
 
@@ -18,7 +19,9 @@ class Kredis::Types::Hash < Kredis::Types::Proxying
   end
 
   def update(**entries)
-    hset entries.transform_values { |val| type_to_string(val, typed) }.compact if entries.flatten.any?
+    with_expiration do
+      hset entries.transform_values { |val| type_to_string(val, typed) }.compact if entries.flatten.any?
+    end
   end
 
   def values_at(*keys)

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -20,7 +20,7 @@ class Kredis::Types::List < Kredis::Types::Proxying
     return if elements.flatten.empty?
 
     lpush types_to_strings(elements, typed)
-    expire_in expires_in if expires_in.present?
+    expire_in expires_in if expires_in
     elements
   end
 
@@ -28,7 +28,7 @@ class Kredis::Types::List < Kredis::Types::Proxying
     return if elements.flatten.empty?
 
     rpush types_to_strings(elements, typed)
-    expire_in expires_in if expires_in.present?
+    expire_in expires_in if expires_in
     elements
   end
   alias << append

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -20,7 +20,7 @@ class Kredis::Types::List < Kredis::Types::Proxying
     return if elements.flatten.empty?
 
     lpush types_to_strings(elements, typed)
-    expire_in expires_in if expires_in
+    expire expires_in.to_i, nx: true if expires_in
     elements
   end
 
@@ -28,7 +28,7 @@ class Kredis::Types::List < Kredis::Types::Proxying
     return if elements.flatten.empty?
 
     rpush types_to_strings(elements, typed)
-    expire_in expires_in if expires_in
+    expire expires_in.to_i, nx: true if expires_in
     elements
   end
   alias << append
@@ -39,10 +39,6 @@ class Kredis::Types::List < Kredis::Types::Proxying
 
   def last(n = nil)
     n ? lrange(-n, -1) : lrange(-1, -1).first
-  end
-
-  def expire_in(seconds)
-    expire seconds.to_i
   end
 
   private

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -17,19 +17,18 @@ class Kredis::Types::List < Kredis::Types::Proxying
     types_to_strings(elements, typed).each { |element| lrem 0, element }
   end
 
-  def prepend(*elements)
+  def prepend(*elements, suppress_expiration: false)
     return if elements.flatten.empty?
 
-    with_expiration do
+    with_expiration(suppress: suppress_expiration) do
       lpush types_to_strings(elements, typed)
     end
   end
 
-  def append(*elements)
+  def append(*elements, suppress_expiration: false)
     return if elements.flatten.empty?
 
-
-    with_expiration do
+    with_expiration(suppress: suppress_expiration) do
       rpush types_to_strings(elements, typed)
     end
   end

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -48,10 +48,10 @@ class Kredis::Types::List < Kredis::Types::Proxying
     end
 
     def with_expiration(&block)
-      block.call.tap do
-        if expires_in && ttl < 0
-          expire expires_in.to_i
-        end
+      result = block.call
+      if expires_in && ttl < 0
+        expire expires_in.to_i
       end
+      result
     end
 end

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -2,10 +2,11 @@
 
 class Kredis::Types::List < Kredis::Types::Proxying
   prepend Kredis::DefaultValues
+  include Kredis::Expiration
 
-  proxying :lrange, :lrem, :lpush, :ltrim, :rpush, :exists?, :del, :expire, :ttl
+  proxying :lrange, :lrem, :lpush, :ltrim, :rpush, :exists?, :del
 
-  attr_accessor :typed, :expires_in
+  attr_accessor :typed
 
   def elements
     strings_to_types(lrange(0, -1) || [], typed)
@@ -45,13 +46,5 @@ class Kredis::Types::List < Kredis::Types::Proxying
   private
     def set_default
       append default
-    end
-
-    def with_expiration(&block)
-      result = block.call
-      if expires_in && ttl < 0
-        expire expires_in.to_i
-      end
-      result
     end
 end

--- a/lib/kredis/types/ordered_set.rb
+++ b/lib/kredis/types/ordered_set.rb
@@ -2,6 +2,7 @@
 
 class Kredis::Types::OrderedSet < Kredis::Types::Proxying
   prepend Kredis::DefaultValues
+  include Kredis::Expiration
 
   proxying :multi, :zrange, :zrem, :zadd, :zremrangebyrank, :zcard, :exists?, :del, :zscore
 
@@ -53,9 +54,11 @@ class Kredis::Types::OrderedSet < Kredis::Types::Proxying
         [ score, element ]
       end
 
-      multi do
-        zadd(elements_with_scores)
-        trim(from_beginning: prepending)
+      with_expiration do
+        multi do
+          zadd(elements_with_scores)
+          trim(from_beginning: prepending)
+        end
       end
     end
 

--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -2,6 +2,7 @@
 
 class Kredis::Types::Set < Kredis::Types::Proxying
   prepend Kredis::DefaultValues
+  include Kredis::Expiration
 
   proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop, :exists?, :srandmember, :smove
 
@@ -16,7 +17,11 @@ class Kredis::Types::Set < Kredis::Types::Proxying
   alias to_a members
 
   def add(*members)
-    sadd types_to_strings(members, typed) if members.flatten.any?
+    return unless members.flatten.any?
+
+    with_expiration do
+      sadd types_to_strings(members, typed)
+    end
   end
   alias << add
 

--- a/lib/kredis/types/unique_list.rb
+++ b/lib/kredis/types/unique_list.rb
@@ -12,7 +12,6 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     return if elements.empty?
 
     with_expiration do
-
       multi do
         remove elements
         super(elements, suppress_expiration: true)
@@ -26,7 +25,6 @@ class Kredis::Types::UniqueList < Kredis::Types::List
     return if elements.empty?
 
     with_expiration do
-
       multi do
         remove elements
         super(elements, suppress_expiration: true)

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -18,6 +18,7 @@ class Person
   kredis_unique_list :skills_with_default_via_lambda, default: ->(p) { [ "Random", "Random", p.name ] }
   kredis_unique_list :skills_with_ttl, expires_in: 1.second
   kredis_ordered_set :reading_list, limit: 2
+  kredis_ordered_set :reading_list_with_ttl, expires_in: 1.second
   kredis_flag :special
   kredis_flag :temporary_special, expires_in: 1.second
   kredis_string :address
@@ -182,6 +183,14 @@ class AttributesTest < ActiveSupport::TestCase
   test "ordered set" do
     @person.reading_list.prepend(%w[ rework shapeup remote ])
     assert_equal %w[ remote shapeup ], @person.reading_list.elements
+  end
+
+  test "ordered set with ttl" do
+    @person.reading_list_with_ttl.prepend(%w[ rework ])
+    assert_equal %w[ rework ], @person.reading_list_with_ttl.elements
+
+    sleep 1.1
+    assert_equal [], @person.reading_list_with_ttl.elements
   end
 
   test "flag" do

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -13,8 +13,10 @@ class Person
   kredis_list :names_with_custom_key_via_lambda, key: ->(p) { "person:#{p.id}:names_customized" }
   kredis_list :names_with_custom_key_via_method, key: :generate_key
   kredis_list :names_with_default_via_lambda, default: ->(p) { [ "Random", p.name ] }
+  kredis_list :names_with_ttl, expires_in: 1.second
   kredis_unique_list :skills, limit: 2
   kredis_unique_list :skills_with_default_via_lambda, default: ->(p) { [ "Random", "Random", p.name ] }
+  kredis_unique_list :skills_with_ttl, expires_in: 1.second
   kredis_ordered_set :reading_list, limit: 2
   kredis_flag :special
   kredis_flag :temporary_special, expires_in: 1.second
@@ -34,6 +36,7 @@ class Person
   kredis_slots :meetings, available: 3
   kredis_set :vacations
   kredis_set :vacations_with_default_via_lambda, default: ->(p) { JSON.parse(p.vacation_destinations).map { |location| location["city"] } }
+  kredis_set :vacations_with_ttl, expires_in: 1.second
   kredis_json :settings
   kredis_json :settings_with_default_via_lambda, default: ->(p) { JSON.parse(p.anthropometry).merge(eye_color: p.eye_color) }
   kredis_counter :amount
@@ -148,6 +151,14 @@ class AttributesTest < ActiveSupport::TestCase
     assert_equal %w[ Random Jason ], Kredis.redis.lrange(Kredis.namespaced_key("people:8:names_with_default_via_lambda"), 0, -1)
   end
 
+  test "list with ttl" do
+    @person.names_with_ttl.append(%w[ david kasper ])
+    assert_equal %w[ david kasper ], @person.names_with_ttl.elements
+
+    sleep 1.1
+    assert_equal [], @person.names_with_ttl.elements
+  end
+
   test "unique list" do
     @person.skills.prepend(%w[ trolling photography ])
     @person.skills.prepend("racing")
@@ -158,6 +169,14 @@ class AttributesTest < ActiveSupport::TestCase
   test "unique list with default proc value" do
     assert_equal %w[ Random Jason ], @person.skills_with_default_via_lambda.elements
     assert_equal %w[ Random Jason ], Kredis.redis.lrange(Kredis.namespaced_key("people:8:skills_with_default_via_lambda"), 0, -1)
+  end
+
+  test "unique list with ttl" do
+    @person.skills_with_ttl.prepend(%w[ trolling photography ])
+    assert_equal %w[ trolling photography ].to_set, @person.skills_with_ttl.elements.to_set
+
+    sleep 1.1
+    assert_equal [], @person.skills_with_ttl.elements
   end
 
   test "ordered set" do
@@ -322,6 +341,14 @@ class AttributesTest < ActiveSupport::TestCase
   test "set with default proc value" do
     assert_equal [ "Paris" ], @person.vacations_with_default_via_lambda.members
     assert_equal [ "Paris" ], Kredis.redis.smembers(Kredis.namespaced_key("people:8:vacations_with_default_via_lambda"))
+  end
+
+  test "set with ttl" do
+    @person.vacations_with_ttl.add "paris"
+    assert_equal [ "paris" ], @person.vacations_with_ttl.members
+
+    sleep 1.1
+    assert_equal [], @person.vacations_with_ttl.members
   end
 
   test "json" do

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -130,4 +130,14 @@ class HashTest < ActiveSupport::TestCase
     assert_nil @hash["key"]
     assert_equal "value2", @hash["key2"]
   end
+
+  test "support ttl" do
+    @hash = Kredis.hash "myhash", expires_in: 1.second
+    @hash[:key] = :value
+    @hash.update("key2" => "value2", "key3" => "value3")
+    assert_equal "value", @hash[:key]
+
+    sleep 1.1
+    assert_equal [], @hash.keys
+  end
 end

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -78,9 +78,12 @@ class ListTest < ActiveSupport::TestCase
 
   test "append with expiring list" do
     @list = Kredis.list "mylist", expires_in: 1.second
-    @list.append(%w[1 2 3])
-
-    sleep 0.5.seconds
+    @list.append(%w[1 2])
+    
+    sleep 0.2.seconds
+    @list.append(3)
+    
+    sleep 0.3.seconds
     assert_equal %w[ 1 2 3 ], @list.elements
 
     sleep 0.6.seconds
@@ -89,9 +92,12 @@ class ListTest < ActiveSupport::TestCase
 
   test "prepend with expiring list" do
     @list = Kredis.list "mylist", expires_in: 1.second
-    @list.prepend(%w[1 2 3])
+    @list.prepend(%w[1 2])
 
-    sleep 0.5.seconds
+    sleep 0.2.seconds
+    @list.prepend(3)
+
+    sleep 0.3.seconds
     assert_equal %w[ 3 2 1 ], @list.elements
 
     sleep 0.6.seconds

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -79,10 +79,10 @@ class ListTest < ActiveSupport::TestCase
   test "append with expiring list" do
     @list = Kredis.list "mylist", expires_in: 1.second
     @list.append(%w[1 2])
-    
+
     sleep 0.2.seconds
     @list.append(3)
-    
+
     sleep 0.3.seconds
     assert_equal %w[ 1 2 3 ], @list.elements
 

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -76,6 +76,27 @@ class ListTest < ActiveSupport::TestCase
     assert_equal %w[ 2 3 ], @list.elements
   end
 
+  test "append with expiring list" do
+    @list = Kredis.list "mylist", expires_in: 1.second
+    @list.append(%w[1 2 3])
+
+    sleep 0.5.seconds
+    assert_equal %w[ 1 2 3 ], @list.elements
+
+    sleep 0.6.seconds
+    assert_equal [], @list.elements
+  end
+
+  test "prepend with expiring list" do
+    @list = Kredis.list "mylist", expires_in: 1.second
+    @list.prepend(%w[1 2 3])
+
+    sleep 0.5.seconds
+    assert_equal %w[ 3 2 1 ], @list.elements
+
+    sleep 0.6.seconds
+    assert_equal [], @list.elements
+  end
 
   test "default" do
     @list = Kredis.list "mylist", default: %w[ 1 2 3 ]

--- a/test/types/ordered_set_test.rb
+++ b/test/types/ordered_set_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "active_support/core_ext/integer"
 
 class OrderedSetTest < ActiveSupport::TestCase
   setup { @set = Kredis.ordered_set "ordered-set", limit: 5 }
@@ -29,6 +30,16 @@ class OrderedSetTest < ActiveSupport::TestCase
 
     thousand_elements.each { |element| @set.append(element) }
     assert_equal thousand_elements, @set.elements
+  end
+
+  test "append with expiry" do
+    @set = Kredis.ordered_set "ordered-set", limit: 5, expires_in: 1.second
+
+    @set.append(%w[ 1 2 3 ])
+    assert_equal %w[ 1 2 3 ], @set.elements
+
+    sleep 1.1
+    assert @set.elements.empty?
   end
 
   test "prepend" do

--- a/test/types/set_test.rb
+++ b/test/types/set_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "active_support/core_ext/object/inclusion"
+require "active_support/core_ext/integer"
 
 class SetTest < ActiveSupport::TestCase
   setup { @set = Kredis.set "myset" }
@@ -155,6 +156,18 @@ class SetTest < ActiveSupport::TestCase
     @set = Kredis.set "mylist", typed: :integer, default: -> () { %w[ 1 2 3 ] }
     @set.add(%w[ 5 6 7 ])
     assert_equal [ 1, 2, 3, 5, 6, 7 ], @set.members
+  end
+
+  test "add with expiration" do
+    @set = Kredis.set "mylist", typed: :integer, expires_in: 1.second
+    @set.add(%w[ 1 2 3 ])
+
+    sleep 0.7.seconds
+    @set.add(%w[ 4 5 ])
+    assert_equal [1, 2, 3, 4, 5], @set.members
+
+    sleep 0.5.seconds
+    assert_equal [], @set.members
   end
 
   test "remove with default" do

--- a/test/types/set_test.rb
+++ b/test/types/set_test.rb
@@ -164,7 +164,7 @@ class SetTest < ActiveSupport::TestCase
 
     sleep 0.7.seconds
     @set.add(%w[ 4 5 ])
-    assert_equal [1, 2, 3, 4, 5], @set.members
+    assert_equal [ 1, 2, 3, 4, 5 ], @set.members
 
     sleep 0.5.seconds
     assert_equal [], @set.members

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "active_support/core_ext/integer"
 
 class UniqueListTest < ActiveSupport::TestCase
   setup { @list = Kredis.unique_list "myuniquelist", limit: 5 }
@@ -12,6 +13,16 @@ class UniqueListTest < ActiveSupport::TestCase
 
     @list << "5"
     assert_equal %w[ 1 2 3 4 5 ], @list.elements
+  end
+
+  test "append with expiration" do
+    @list = Kredis.unique_list "xs", limit: 5, expires_in: 1.second
+
+    @list.append(%w[ 1 2 3 ])
+    assert_equal %w[ 1 2 3 ], @list.elements
+
+    sleep 1.1
+    assert @list.elements.empty?
   end
 
   test "prepend" do


### PR DESCRIPTION
Extending the approach taken by https://github.com/rails/kredis/pull/142, now users can set `expires_in` for `List`, `Set`, `UniqueList`, `OrderedSet`