### PR TITLE
Kredis.hash fails with nil values in Redis 5+

### DIFF
--- a/lib/kredis/types/hash.rb
+++ b/lib/kredis/types/hash.rb
@@ -18,7 +18,7 @@ class Kredis::Types::Hash < Kredis::Types::Proxying
   end
 
   def update(**entries)
-    hset entries.transform_values { |val| type_to_string(val, typed) } if entries.flatten.any?
+    hset entries.transform_values { |val| type_to_string(val, typed) }.compact if entries.flatten.any?
   end
 
   def values_at(*keys)

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -124,4 +124,10 @@ class HashTest < ActiveSupport::TestCase
     @hash = Kredis.hash "myhash", typed: :integer, default: ->() { { space_invaders: "100", pong: "42" } }
     assert_equal({ "space_invaders" => 100, "pong" => 42 }, @hash.to_h)
   end
+
+  test "does not support nil values" do
+    assert_raises do
+      @hash.update("key" => nil)
+    end
+  end
 end

--- a/test/types/hash_test.rb
+++ b/test/types/hash_test.rb
@@ -125,9 +125,9 @@ class HashTest < ActiveSupport::TestCase
     assert_equal({ "space_invaders" => 100, "pong" => 42 }, @hash.to_h)
   end
 
-  test "does not support nil values" do
-    assert_raises do
-      @hash.update("key" => nil)
-    end
+  test "handles nil values gracefully" do
+    @hash.update("key" => nil, "key2" => "value2")
+    assert_nil @hash["key"]
+    assert_equal "value2", @hash["key2"]
   end
 end


### PR DESCRIPTION
We've been bite several times in production by trying to set a kredis hash with the value of a key being `nil`. As we know, accidental `nil`s are not rare in Ruby :(

Kredis attempts to call `hset` in redis with a nil value, which is not supported and you get this exception:

```ruby
/Users/matt/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/redis-client-0.19.1/lib/redis_client/command_builder.rb:37:in `block in generate': 
Unsupported command argument type: nil (TypeError)

            raise TypeError, "Unsupported command argument type: #{element.class}"
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This PR runs `Hash#compact` on the values passed to Kredis before trying to send them to Redis via `hset`. This would remove invalid key/value pairs. Later, when reading the stored hash back, you would rely on the Ruby default return value of `nil` when accessing a non-existing key.