### PR TITLE
Define a missing method #root for the development configurator

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -14,7 +14,10 @@ end
 
 require "debug"
 
-Kredis.configurator = Class.new { def config_for(name) { db: "2" } end }.new
+Kredis.configurator = Class.new do
+  def config_for(name) { db: "2" } end
+  def root() Pathname.new(".") end
+end.new
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT)
 
 IRB.start


### PR DESCRIPTION
This fixes an unexpected NoMethodError that experimenting through `bin/console` causes:

```
irb(main):001> Kredis.string "mystring"

/rails/kredis/lib/kredis/connections.rb:15:in `block in configured_for': undefined method `root' for an instance of #<Class:0x0000000108091a60> (NoMethodError)

      if configurator.root.join("config/redis/#{name}.yml").exist?
                     ^^^^^
```

This is a follow-up to https://github.com/rails/kredis/pull/135.