### PR TITLE
Add `include?` to list, uniquelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ integer_list = Kredis.list "myintegerlist", typed: :integer, default: [ 1, 2, 3 
 integer_list.append([ 4, 5, 6 ])                                                  # => RPUSH myintegerlist "4" "5" "6"
 integer_list << 7                                                                 # => RPUSH myintegerlist "7"
 [ 1, 2, 3, 4, 5, 6, 7 ] == integer_list.elements                                  # => LRANGE myintegerlist 0 -1
+integer_list.include? 7
 
 unique_list = Kredis.unique_list "myuniquelist"
 unique_list.append(%w[ 2 3 4 ])                # => LREM myuniquelist 0, "2" + LREM myuniquelist 0, "3" + LREM myuniquelist 0, "4"  + RPUSH myuniquelist "2", "3", "4"

--- a/lib/kredis/types/list.rb
+++ b/lib/kredis/types/list.rb
@@ -3,7 +3,7 @@
 class Kredis::Types::List < Kredis::Types::Proxying
   prepend Kredis::DefaultValues
 
-  proxying :lrange, :lrem, :lpush, :ltrim, :rpush, :exists?, :del
+  proxying :lrange, :lrem, :lpush, :ltrim, :rpush, :exists?, :del, :lpos
 
   attr_accessor :typed
 
@@ -31,6 +31,10 @@ class Kredis::Types::List < Kredis::Types::Proxying
 
   def last(n = nil)
     n ? lrange(-n, -1) : lrange(-1, -1).first
+  end
+
+  def include?(element)
+    !lpos(element).nil?
   end
 
   private

--- a/test/types/list_test.rb
+++ b/test/types/list_test.rb
@@ -131,4 +131,12 @@ class ListTest < ActiveSupport::TestCase
 
     assert_equal [ 0, 1, 2, 3, 4, 10, 20, 30 ], Kredis.list("mylist", typed: :integer).to_a.sort
   end
+
+  test "include?" do
+    list = Kredis.list "int-list", typed: :integer
+    list.append [ 1, 2, 3 ]
+
+    assert list.include?(1)
+    assert_not list.include?(4)
+  end
 end

--- a/test/types/unique_list_test.rb
+++ b/test/types/unique_list_test.rb
@@ -93,4 +93,10 @@ class UniqueListTest < ActiveSupport::TestCase
     @list.prepend(%w[ 6 7 8 ])
     assert_equal %w[ 8 7 6 1 2 3 ], @list.elements
   end
+
+  test "include?" do
+    @list.append(%w[ 1 2 3 ])
+    assert @list.include?("1")
+    assert_not @list.include?("4")
+  end
 end


### PR DESCRIPTION
# Motivation
- Support `include?` method for `Kredis::Types::List`

# Modification
- Allow `List` to proxy `lpos` (refer: https://redis.io/commands/lpos/)
- Add some example of `List#include?`

# Result
- Users can use `include?` without load members of list to memory