### PR TITLE
Add `Kredis#redis_version`

### DIFF
--- a/lib/kredis.rb
+++ b/lib/kredis.rb
@@ -13,11 +13,12 @@ require "kredis/type_casting"
 require "kredis/default_values"
 require "kredis/types"
 require "kredis/attributes"
+require "kredis/info"
 
 require "kredis/railtie" if defined?(Rails::Railtie)
 
 module Kredis
-  include Connections, Namespace, TypeCasting, Types
+  include Connections, Namespace, TypeCasting, Types, Info
   extend self
 
   autoload :Migration, "kredis/migration"

--- a/lib/kredis/info.rb
+++ b/lib/kredis/info.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Kredis::Info
+  def redis_version
+    redis_versions.first
+  end
+
+  def redis_versions
+    Array.wrap(Kredis.redis.info("server")).tap do |versions|
+      versions.map! { |v| v["redis_version"] }
+      versions.map! { |v| Gem::Version.new(v) }
+    end
+  end
+end

--- a/test/kredis/info_test.rb
+++ b/test/kredis/info_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "yaml"
+
+class InfoTest < ActiveSupport::TestCase
+  test "version" do
+    assert Kredis.redis_version >= Gem::Version.new("4.0.0")
+  end
+end


### PR DESCRIPTION
There are many commands supported on only high versions of redis. For example `LPOS` or `NX` option in `EXPIRE`. So, if we can get version of current redis, we can implement some commands more effectively. 