### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ end
 
 person = Person.find(5)
 person.names.append "David", "Heinemeier", "Hansson" # => RPUSH people:5:names "David" "Heinemeier" "Hansson"
+Note: people is fabricate by "person".pluralize
 true == person.morning.bright?                       # => GET people:5:morning
 person.morning.value = "blue"                        # => SET people:5:morning
 true == person.morning.blue?                         # => GET people:5:morning


### PR DESCRIPTION
Ruby on Rails pluralize class names by convention. So Person model generate people when performing people=person.pluralize.